### PR TITLE
Update to Version Bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,14 @@ jobs:
         # Update __init__.py dynamically
         sed -i "s/__version__ = \".*\"/__version__ = \"${{ env.VERSION }}\"/" elastro/__init__.py
         
+        # Commit the version bump back to the repository so subsequent runs do not stick on old versions
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        git add pyproject.toml elastro/__init__.py
+        # Use || true to prevent failure if it's already committed (e.g. manual bump)
+        git commit -m "chore(release): bump version to ${{ env.VERSION }} [skip ci]" || true
+        git push origin main || true
+        
         # Build wheel and sdist
         python -m build
 

--- a/elastro/__init__.py
+++ b/elastro/__init__.py
@@ -4,7 +4,7 @@ Elasticsearch Management Module.
 A module for managing Elasticsearch operations within a pipeline process.
 """
 
-__version__ = "1.3.12"
+__version__ = "1.3.14"
 
 # Core component imports
 from elastro.core.client import ElasticsearchClient

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "elastro-client"
-version = "1.3.12"
+version = "1.3.14"
 description = "A comprehensive Python library for Elasticsearch management with both programmatic and CLI interfaces"
 readme = "README.md"
 requires-python = ">=3.9,<3.14"


### PR DESCRIPTION
injected a git commit step directly into .github/workflows/release.yml immediately after the sed string replacements. Now, the github-actions[bot] automatically commits the pyproject.toml and __init__.py changes and pushes them back to main.