### PR TITLE
fix(cli): enforce Netflix standard for exception logging

### DIFF
--- a/elastro/cli/cli.py
+++ b/elastro/cli/cli.py
@@ -23,10 +23,12 @@ if len(sys.argv) >= 3 and sys.argv[1] == "doc" and sys.argv[2] == "search":
             if result:
                 print(result, end="")
                 sys.exit(0)
-        except Exception:
+        except Exception as e:
             # If the daemon is offline or crashes, silently fall through
             # to the normal heavy Click execution.
-            pass
+            import logging
+
+            logging.getLogger("elastro.cli").debug(f"Fast-path daemon bypass: {e}")
 # --- END FAST PATH INTERCEPTOR ---
 
 import os

--- a/elastro/cli/commands/gui.py
+++ b/elastro/cli/commands/gui.py
@@ -35,8 +35,10 @@ def gui() -> None:
                 console.print(
                     f"[dim]Initialized default CLI configuration at {config_path}[/dim]"
                 )
-            except Exception:
-                pass
+            except Exception as e:
+                console.print(
+                    f"[dim yellow]Warning: Could not save default config: {e}[/dim yellow]"
+                )
 
         url = launch_gui_process()
 


### PR DESCRIPTION
Purges two occurrences of silent bare 'pass' exception blocks via explicit console and diagnostic log warnings without impeding fallback resilience.