### PR TITLE
Phase 2 — sanitizers, pipeline builder, and pipeline

### DIFF
--- a/elastro/cli/commands/ingest.py
+++ b/elastro/cli/commands/ingest.py
@@ -626,3 +626,309 @@ def validate_data(
     console.print(
         f"\n[dim]Mode: {mode} | {total} docs checked | {valid} valid, {invalid} invalid[/dim]"
     )
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Pipeline subgroup
+# ---------------------------------------------------------------------------
+
+
+@ingest_group.group(name="pipeline")
+def pipeline_group() -> None:
+    """Manage Elasticsearch ingest pipelines.
+
+    Build, deploy, and manage ingest pipelines interactively
+    or from file definitions.
+    """
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Pipeline Wizard
+# ---------------------------------------------------------------------------
+
+# Available processor types for the wizard
+_PROCESSOR_TYPES = [
+    ("grok", "Parse unstructured text with Grok patterns"),
+    ("date", "Parse and normalize timestamps"),
+    ("geoip", "Enrich IP addresses with geo data"),
+    ("convert", "Convert field types (string → int, etc.)"),
+    ("rename", "Rename fields"),
+    ("remove", "Remove fields"),
+    ("lowercase", "Convert field values to lowercase"),
+    ("uppercase", "Convert field values to uppercase"),
+    ("gsub", "Regex find-and-replace on field values"),
+    ("set", "Set a field to a static or template value"),
+    ("redact", "Redact PII patterns from fields"),
+    ("dissect", "Delimiter-based field extraction"),
+    ("script", "Custom Painless script"),
+]
+
+
+@pipeline_group.command(name="wizard")
+@click.pass_obj
+def pipeline_wizard(client: ElasticsearchClient) -> None:
+    """Interactively build and deploy an Elasticsearch ingest pipeline.
+
+    Walks through processor selection and configuration, previews
+    the resulting JSON, and optionally deploys to the cluster.
+
+    Example:
+
+    ```bash
+    elastro ingest pipeline wizard
+    ```
+    """
+    from rich.prompt import Confirm, IntPrompt, Prompt
+
+    from elastro.core.ingest.pipeline_builder import IngestPipelineBuilder
+
+    console = Console()
+    console.print(
+        Panel.fit(
+            "[bold cyan]Elastro Ingest Pipeline Builder[/bold cyan]\n"
+            "Build a production-ready ingest pipeline interactively.",
+            border_style="cyan",
+        )
+    )
+
+    # --- Step 1: Pipeline metadata ---
+    pipeline_id = Prompt.ask("\n[bold]1. Pipeline ID[/bold]", default="my-pipeline")
+    desc = Prompt.ask("[bold]2. Description[/bold]", default="")
+
+    builder = IngestPipelineBuilder(pipeline_id)
+    if desc:
+        builder.description(desc)
+
+    # --- Step 2: Select processors ---
+    console.print("\n[bold]3. Select processors to add:[/bold]")
+    for i, (name, description) in enumerate(_PROCESSOR_TYPES, 1):
+        console.print(f"   {i:2d}. [cyan]{name:<12}[/cyan] — {description}")
+
+    selected_input = Prompt.ask(
+        "\n   Enter processor numbers (comma-separated)",
+        default="1",
+    )
+    selected_indices: list[int] = []
+    for part in selected_input.split(","):
+        part = part.strip()
+        if part.isdigit():
+            idx = int(part) - 1
+            if 0 <= idx < len(_PROCESSOR_TYPES):
+                selected_indices.append(idx)
+
+    if not selected_indices:
+        console.print("[yellow]No processors selected. Aborting.[/yellow]")
+        return
+
+    selected_processors = [_PROCESSOR_TYPES[i] for i in selected_indices]
+    console.print(
+        f"\n   [green]✓ Selected:[/green] "
+        + ", ".join(p[0] for p in selected_processors)
+    )
+
+    # --- Step 3: Configure each processor ---
+    for proc_name, proc_desc in selected_processors:
+        console.print(f"\n[bold]Configure [cyan]{proc_name}[/cyan]:[/bold]")
+        _configure_processor(builder, proc_name, console)
+
+    # --- Step 4: On-failure handler ---
+    if Confirm.ask(
+        "\n[bold]4. Add on_failure handler?[/bold] (route errors to a DLQ index)",
+        default=False,
+    ):
+        dlq_index = Prompt.ask(
+            "   Dead-letter index name", default=f"failed-{pipeline_id}"
+        )
+        builder.on_failure(dlq_index)
+        console.print(f"   [green]✓ On-failure → {dlq_index}[/green]")
+
+    # --- Step 5: Preview ---
+    pipeline_json = builder.build()
+    json_str = json.dumps(pipeline_json, indent=2)
+    console.print("\n[bold]5. Pipeline Preview:[/bold]")
+    console.print(Syntax(json_str, "json", theme="monokai"))
+    console.print(f"\n[dim]{builder.processor_count} processor(s) configured[/dim]")
+
+    # --- Step 6: Deploy ---
+    if Confirm.ask(
+        f"\n[bold]Deploy pipeline '{pipeline_id}' to cluster?[/bold]",
+        default=False,
+    ):
+        try:
+            builder.deploy(client, pipeline_id=pipeline_id)
+            console.print(
+                f"\n[bold green]✓ Pipeline '{pipeline_id}' deployed "
+                f"successfully![/bold green]"
+            )
+        except Exception as e:
+            console.print(f"\n[bold red]Deploy failed:[/bold red] {e}")
+    else:
+        # Offer to save to file
+        if Confirm.ask("Save pipeline JSON to file?", default=True):
+            output_path = Prompt.ask("   Output file", default=f"{pipeline_id}.json")
+            Path(output_path).write_text(json_str, encoding="utf-8")
+            console.print(f"   [green]✓ Saved to {output_path}[/green]")
+
+
+def _configure_processor(
+    builder: Any,
+    proc_name: str,
+    console: Console,
+) -> None:
+    """Prompt the user for processor-specific configuration."""
+    from rich.prompt import Prompt
+
+    if proc_name == "grok":
+        field = Prompt.ask("   Field to parse", default="message")
+        pattern = Prompt.ask("   Grok pattern", default="%{COMBINEDAPACHELOG}")
+        builder.grok(field, [pattern])
+
+    elif proc_name == "date":
+        field = Prompt.ask("   Source field", default="timestamp")
+        fmt = Prompt.ask("   Date format", default="dd/MMM/yyyy:HH:mm:ss Z")
+        target = Prompt.ask("   Target field", default="@timestamp")
+        builder.date(field, [fmt], target_field=target)
+
+    elif proc_name == "geoip":
+        field = Prompt.ask("   IP address field", default="clientip")
+        builder.geoip(field)
+
+    elif proc_name == "convert":
+        field = Prompt.ask("   Field to convert", default="status_code")
+        target_type = Prompt.ask(
+            "   Target type",
+            default="integer",
+        )
+        builder.convert(field, target_type)
+
+    elif proc_name == "rename":
+        field = Prompt.ask("   Source field")
+        target = Prompt.ask("   Target field name")
+        builder.rename(field, target)
+
+    elif proc_name == "remove":
+        field = Prompt.ask("   Field to remove")
+        builder.remove(field, ignore_missing=True)
+
+    elif proc_name == "lowercase":
+        field = Prompt.ask("   Field to lowercase")
+        builder.lowercase(field)
+
+    elif proc_name == "uppercase":
+        field = Prompt.ask("   Field to uppercase")
+        builder.uppercase(field)
+
+    elif proc_name == "gsub":
+        field = Prompt.ask("   Field")
+        pattern = Prompt.ask("   Regex pattern")
+        replacement = Prompt.ask("   Replacement string")
+        builder.gsub(field, pattern, replacement)
+
+    elif proc_name == "set":
+        field = Prompt.ask("   Field name")
+        value = Prompt.ask("   Value (static or {{template}})")
+        builder.set_field(field, value)
+
+    elif proc_name == "redact":
+        field = Prompt.ask("   Field to redact", default="message")
+        pattern = Prompt.ask(
+            "   Grok redaction pattern", default="%{EMAILADDRESS:REDACTED}"
+        )
+        builder.redact(field, [pattern])
+
+    elif proc_name == "dissect":
+        field = Prompt.ask("   Field to parse", default="message")
+        pattern = Prompt.ask("   Dissect pattern")
+        builder.dissect(field, pattern)
+
+    elif proc_name == "script":
+        source = Prompt.ask("   Painless script source")
+        builder.script(source)
+
+    console.print(f"   [green]✓ {proc_name} configured[/green]")
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Pipeline create / delete
+# ---------------------------------------------------------------------------
+
+
+@pipeline_group.command(name="create", no_args_is_help=True)
+@click.argument("pipeline_id", type=str)
+@click.option(
+    "--file",
+    "-f",
+    "pipeline_file",
+    type=click.File("r"),
+    required=True,
+    help="Path to pipeline definition JSON file",
+)
+@click.pass_obj
+def pipeline_create(
+    client: ElasticsearchClient,
+    pipeline_id: str,
+    pipeline_file: Any,
+) -> None:
+    """Deploy an ingest pipeline from a JSON file.
+
+    Example:
+
+    ```bash
+    elastro ingest pipeline create web-logs --file ./pipeline.json
+    ```
+    """
+    console = Console()
+    try:
+        body = json.load(pipeline_file)
+        es = client.client
+        es.ingest.put_pipeline(id=pipeline_id, body=body)
+        proc_count = len(body.get("processors", []))
+        console.print(
+            f"[bold green]✓ Pipeline '{pipeline_id}' deployed "
+            f"({proc_count} processors)[/bold green]"
+        )
+    except json.JSONDecodeError:
+        console.print("[bold red]Error:[/bold red] File is not valid JSON.")
+        raise SystemExit(1)
+    except Exception as e:
+        console.print(f"[bold red]Error deploying pipeline:[/bold red] {e}")
+        raise SystemExit(1)
+
+
+@pipeline_group.command(name="delete", no_args_is_help=True)
+@click.argument("pipeline_id", type=str)
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
+@click.pass_obj
+def pipeline_delete(
+    client: ElasticsearchClient,
+    pipeline_id: str,
+    yes: bool,
+) -> None:
+    """Delete an ingest pipeline.
+
+    Example:
+
+    ```bash
+    elastro ingest pipeline delete web-logs
+    ```
+    """
+    from rich.prompt import Confirm
+
+    console = Console()
+
+    if not yes:
+        if not Confirm.ask(
+            f"Delete pipeline [bold red]{pipeline_id}[/bold red]?",
+            default=False,
+        ):
+            console.print("[dim]Aborted.[/dim]")
+            return
+
+    try:
+        es = client.client
+        es.ingest.delete_pipeline(id=pipeline_id)
+        console.print(f"[bold green]✓ Pipeline '{pipeline_id}' deleted[/bold green]")
+    except Exception as e:
+        console.print(f"[bold red]Error:[/bold red] {e}")
+        raise SystemExit(1)

--- a/elastro/core/ingest/__init__.py
+++ b/elastro/core/ingest/__init__.py
@@ -7,10 +7,13 @@ sources and Elasticsearch:
 - Multi-format readers (CSV, NDJSON, JSON, SQL)
 - Schema validation and type coercion
 - Data profiling and PII risk assessment
+- Client-side sanitization (PII redaction, dedup, field filtering)
+- Fluent ingest pipeline builder
 - Dead-letter queue for failed documents
 """
 
 from elastro.core.ingest.engine import IngestEngine, IngestResult
+from elastro.core.ingest.pipeline_builder import IngestPipelineBuilder
 from elastro.core.ingest.readers import (
     read_source,
     CSVReader,
@@ -19,11 +22,14 @@ from elastro.core.ingest.readers import (
     SQLReader,
     SQLDumpReader,
 )
+from elastro.core.ingest.sanitizers import SanitizationChain
 from elastro.core.ingest.validators import SchemaValidator, infer_mapping
 
 __all__ = [
     "IngestEngine",
     "IngestResult",
+    "IngestPipelineBuilder",
+    "SanitizationChain",
     "read_source",
     "CSVReader",
     "NDJSONReader",

--- a/elastro/core/ingest/pipeline_builder.py
+++ b/elastro/core/ingest/pipeline_builder.py
@@ -1,0 +1,354 @@
+"""
+Fluent builder for Elasticsearch ingest pipeline definitions.
+
+Allows programmatic construction of pipeline JSON via a chained
+method API, with optional deployment to a live cluster.
+
+Example::
+
+    pipeline = (
+        IngestPipelineBuilder("web-logs")
+        .description("Parse and enrich web access logs")
+        .grok("message", ["%{COMBINEDAPACHELOG}"])
+        .date("timestamp", ["dd/MMM/yyyy:HH:mm:ss Z"])
+        .geoip("clientip")
+        .convert("response", "integer")
+        .rename("clientip", "client.ip")
+        .remove("message")
+        .on_failure("failed-web-logs")
+        .build()
+    )
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from elastro.core.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class IngestPipelineBuilder:
+    """Fluent builder for Elasticsearch ingest pipeline definitions.
+
+    Each processor method appends to an internal list and returns
+    ``self`` so calls can be chained.  Call :meth:`build` to produce
+    the final JSON dict, or :meth:`deploy` to push it to a cluster.
+    """
+
+    def __init__(self, pipeline_id: str) -> None:
+        self._pipeline_id = pipeline_id
+        self._description: str = ""
+        self._processors: List[Dict[str, Any]] = []
+        self._on_failure: Optional[List[Dict[str, Any]]] = None
+
+    # ------------------------------------------------------------------
+    # Metadata
+    # ------------------------------------------------------------------
+
+    def description(self, text: str) -> IngestPipelineBuilder:
+        """Set the pipeline description."""
+        self._description = text
+        return self
+
+    # ------------------------------------------------------------------
+    # Processors
+    # ------------------------------------------------------------------
+
+    def grok(
+        self,
+        field: str,
+        patterns: List[str],
+        *,
+        ignore_missing: bool = False,
+    ) -> IngestPipelineBuilder:
+        """Add a Grok processor for pattern-based text parsing."""
+        proc: Dict[str, Any] = {
+            "grok": {
+                "field": field,
+                "patterns": patterns,
+            }
+        }
+        if ignore_missing:
+            proc["grok"]["ignore_missing"] = True
+        self._processors.append(proc)
+        return self
+
+    def date(
+        self,
+        field: str,
+        formats: List[str],
+        *,
+        target_field: str = "@timestamp",
+        timezone: Optional[str] = None,
+    ) -> IngestPipelineBuilder:
+        """Add a Date processor for timestamp parsing."""
+        cfg: Dict[str, Any] = {
+            "field": field,
+            "formats": formats,
+            "target_field": target_field,
+        }
+        if timezone:
+            cfg["timezone"] = timezone
+        self._processors.append({"date": cfg})
+        return self
+
+    def rename(
+        self,
+        field: str,
+        target_field: str,
+        *,
+        ignore_missing: bool = False,
+    ) -> IngestPipelineBuilder:
+        """Add a Rename processor."""
+        cfg: Dict[str, Any] = {
+            "field": field,
+            "target_field": target_field,
+        }
+        if ignore_missing:
+            cfg["ignore_missing"] = True
+        self._processors.append({"rename": cfg})
+        return self
+
+    def remove(
+        self,
+        field: str,
+        *,
+        ignore_missing: bool = False,
+    ) -> IngestPipelineBuilder:
+        """Add a Remove processor."""
+        cfg: Dict[str, Any] = {"field": field}
+        if ignore_missing:
+            cfg["ignore_missing"] = True
+        self._processors.append({"remove": cfg})
+        return self
+
+    def convert(
+        self,
+        field: str,
+        target_type: str,
+        *,
+        target_field: Optional[str] = None,
+        ignore_missing: bool = False,
+    ) -> IngestPipelineBuilder:
+        """Add a Convert processor for type conversion."""
+        cfg: Dict[str, Any] = {"field": field, "type": target_type}
+        if target_field:
+            cfg["target_field"] = target_field
+        if ignore_missing:
+            cfg["ignore_missing"] = True
+        self._processors.append({"convert": cfg})
+        return self
+
+    def lowercase(
+        self,
+        field: str,
+        *,
+        ignore_missing: bool = False,
+    ) -> IngestPipelineBuilder:
+        """Add a Lowercase processor."""
+        cfg: Dict[str, Any] = {"field": field}
+        if ignore_missing:
+            cfg["ignore_missing"] = True
+        self._processors.append({"lowercase": cfg})
+        return self
+
+    def uppercase(
+        self,
+        field: str,
+        *,
+        ignore_missing: bool = False,
+    ) -> IngestPipelineBuilder:
+        """Add an Uppercase processor."""
+        cfg: Dict[str, Any] = {"field": field}
+        if ignore_missing:
+            cfg["ignore_missing"] = True
+        self._processors.append({"uppercase": cfg})
+        return self
+
+    def set_field(
+        self,
+        field: str,
+        value: Any,
+    ) -> IngestPipelineBuilder:
+        """Add a Set processor to inject a static or template value."""
+        self._processors.append({"set": {"field": field, "value": value}})
+        return self
+
+    def gsub(
+        self,
+        field: str,
+        pattern: str,
+        replacement: str,
+    ) -> IngestPipelineBuilder:
+        """Add a Gsub processor for regex replacement."""
+        self._processors.append(
+            {
+                "gsub": {
+                    "field": field,
+                    "pattern": pattern,
+                    "replacement": replacement,
+                }
+            }
+        )
+        return self
+
+    def geoip(
+        self,
+        field: str,
+        *,
+        target_field: Optional[str] = None,
+        ignore_missing: bool = True,
+    ) -> IngestPipelineBuilder:
+        """Add a GeoIP enrichment processor."""
+        cfg: Dict[str, Any] = {"field": field}
+        if target_field:
+            cfg["target_field"] = target_field
+        if ignore_missing:
+            cfg["ignore_missing"] = True
+        self._processors.append({"geoip": cfg})
+        return self
+
+    def redact(
+        self,
+        field: str,
+        patterns: List[str],
+        *,
+        pattern_definitions: Optional[Dict[str, str]] = None,
+    ) -> IngestPipelineBuilder:
+        """Add a Redact processor for PII removal."""
+        cfg: Dict[str, Any] = {"field": field, "patterns": patterns}
+        if pattern_definitions:
+            cfg["pattern_definitions"] = pattern_definitions
+        self._processors.append({"redact": cfg})
+        return self
+
+    def dissect(
+        self,
+        field: str,
+        pattern: str,
+        *,
+        append_separator: Optional[str] = None,
+    ) -> IngestPipelineBuilder:
+        """Add a Dissect processor for delimiter-based parsing."""
+        cfg: Dict[str, Any] = {"field": field, "pattern": pattern}
+        if append_separator:
+            cfg["append_separator"] = append_separator
+        self._processors.append({"dissect": cfg})
+        return self
+
+    def script(
+        self,
+        source: str,
+        *,
+        lang: str = "painless",
+        params: Optional[Dict[str, Any]] = None,
+    ) -> IngestPipelineBuilder:
+        """Add a Script processor for custom logic."""
+        cfg: Dict[str, Any] = {"lang": lang, "source": source}
+        if params:
+            cfg["params"] = params
+        self._processors.append({"script": cfg})
+        return self
+
+    def inference(
+        self,
+        model_id: str,
+        *,
+        field_map: Optional[Dict[str, str]] = None,
+        target_field: Optional[str] = None,
+    ) -> IngestPipelineBuilder:
+        """Add an Inference processor for ML model execution."""
+        cfg: Dict[str, Any] = {"model_id": model_id}
+        if field_map:
+            cfg["field_map"] = field_map
+        if target_field:
+            cfg["target_field"] = target_field
+        self._processors.append({"inference": cfg})
+        return self
+
+    def custom(self, processor: Dict[str, Any]) -> IngestPipelineBuilder:
+        """Add an arbitrary processor dict (escape hatch)."""
+        self._processors.append(processor)
+        return self
+
+    # ------------------------------------------------------------------
+    # Failure handling
+    # ------------------------------------------------------------------
+
+    def on_failure(
+        self,
+        dead_letter_index: str,
+    ) -> IngestPipelineBuilder:
+        """Configure on_failure to route errors to a dead-letter index.
+
+        Captures the original document and error metadata.
+        """
+        self._on_failure = [
+            {
+                "set": {
+                    "field": "_index",
+                    "value": dead_letter_index,
+                }
+            },
+            {
+                "set": {
+                    "field": "error.message",
+                    "value": "{{ _ingest.on_failure_message }}",
+                }
+            },
+            {
+                "set": {
+                    "field": "error.processor_type",
+                    "value": "{{ _ingest.on_failure_processor_type }}",
+                }
+            },
+        ]
+        return self
+
+    # ------------------------------------------------------------------
+    # Build & deploy
+    # ------------------------------------------------------------------
+
+    def build(self) -> Dict[str, Any]:
+        """Build the pipeline definition dict.
+
+        Returns:
+            Dict ready for the Elasticsearch Put Pipeline API.
+        """
+        body: Dict[str, Any] = {
+            "description": self._description,
+            "processors": list(self._processors),
+        }
+        if self._on_failure:
+            body["on_failure"] = self._on_failure
+        return body
+
+    @property
+    def pipeline_id(self) -> str:
+        """The pipeline ID this builder was initialized with."""
+        return self._pipeline_id
+
+    @property
+    def processor_count(self) -> int:
+        """Number of processors currently in the pipeline."""
+        return len(self._processors)
+
+    def deploy(
+        self,
+        client: Any,
+        *,
+        pipeline_id: Optional[str] = None,
+    ) -> None:
+        """Deploy the pipeline to an Elasticsearch cluster.
+
+        Args:
+            client: An ``ElasticsearchClient`` instance.
+            pipeline_id: Override the builder's pipeline ID.
+        """
+        pid = pipeline_id or self._pipeline_id
+        body = self.build()
+        es = client.get_client()
+        es.ingest.put_pipeline(id=pid, body=body)
+        logger.info(f"Pipeline '{pid}' deployed ({self.processor_count} processors)")

--- a/elastro/core/ingest/sanitizers.py
+++ b/elastro/core/ingest/sanitizers.py
@@ -1,0 +1,204 @@
+"""
+Client-side data sanitization pipeline for the Ingest Engine.
+
+Provides a configurable chain of document transformations applied
+**before** data reaches Elasticsearch:
+
+- **PII Redaction** — regex-based detection and masking of emails,
+  SSNs, phone numbers, credit cards, and IPv4 addresses.
+- **Content Deduplication** — SHA-256 content hashing with an
+  in-memory set for batch-level dedup.
+- **Field Filtering** — allowlist / denylist field projection.
+- **Value Masking** — pattern-matched field masking (e.g. passwords).
+- **Trim & Normalize** — whitespace stripping and optional lowercasing.
+"""
+
+import hashlib
+import json
+import re
+import unicodedata
+from typing import Any, Dict, FrozenSet, List, Optional, Set, Tuple
+
+from elastro.core.logger import get_logger
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# PII patterns (compiled once, reused across documents)
+# ---------------------------------------------------------------------------
+
+PII_PATTERNS: Dict[str, re.Pattern[str]] = {
+    "email": re.compile(r"\b[\w.+-]+@[\w.-]+\.\w{2,}\b"),
+    "ssn": re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
+    "phone_us": re.compile(r"\b(?:\+1[-.]?)?\(?\d{3}\)?[-.]?\d{3}[-.]?\d{4}\b"),
+    "credit_card": re.compile(r"\b(?:\d[ -]*?){13,19}\b"),
+    "ipv4": re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b"),
+}
+
+# Default replacement tokens per PII type
+_REDACT_TOKENS: Dict[str, str] = {
+    "email": "[REDACTED_EMAIL]",
+    "ssn": "[REDACTED_SSN]",
+    "phone_us": "[REDACTED_PHONE]",
+    "credit_card": "[REDACTED_CC]",
+    "ipv4": "[REDACTED_IP]",
+}
+
+
+# ---------------------------------------------------------------------------
+# Sanitization chain
+# ---------------------------------------------------------------------------
+
+
+class SanitizationChain:
+    """Configurable, ordered chain of document sanitization steps.
+
+    Each step is independently toggleable.  The chain is immutable after
+    construction — create a new instance to change settings.
+
+    Args:
+        redact_pii: Replace detected PII with redaction tokens.
+        pii_types: Which PII types to redact (default: all).
+        dedup: Enable content-hash deduplication.
+        allow_fields: If set, only these fields pass through (allowlist).
+        deny_fields: If set, these fields are removed (denylist).
+        mask_fields: Field name patterns whose values are replaced with
+            ``******`` (e.g. ``["password", "secret", "token"]``).
+        trim: Strip leading/trailing whitespace from string values.
+        normalize_unicode: Apply NFC unicode normalization.
+        lowercase_fields: Field names whose values are lowercased.
+    """
+
+    def __init__(
+        self,
+        *,
+        redact_pii: bool = False,
+        pii_types: Optional[List[str]] = None,
+        dedup: bool = False,
+        allow_fields: Optional[List[str]] = None,
+        deny_fields: Optional[List[str]] = None,
+        mask_fields: Optional[List[str]] = None,
+        trim: bool = True,
+        normalize_unicode: bool = False,
+        lowercase_fields: Optional[List[str]] = None,
+    ) -> None:
+        self.redact_pii = redact_pii
+        self.pii_types: List[str] = pii_types or list(PII_PATTERNS.keys())
+        self.dedup = dedup
+        self.allow_fields: Optional[FrozenSet[str]] = (
+            frozenset(allow_fields) if allow_fields else None
+        )
+        self.deny_fields: FrozenSet[str] = frozenset(deny_fields or [])
+        self.mask_fields: FrozenSet[str] = frozenset(
+            f.lower() for f in (mask_fields or [])
+        )
+        self.trim = trim
+        self.normalize_unicode = normalize_unicode
+        self.lowercase_fields: FrozenSet[str] = frozenset(lowercase_fields or [])
+
+        # Dedup state — in-memory content hash set
+        self._seen_hashes: Set[str] = set()
+        self._dedup_count: int = 0
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def sanitize(self, doc: Dict[str, Any]) -> Tuple[bool, Dict[str, Any]]:
+        """Apply the full sanitization chain to a document.
+
+        Returns:
+            Tuple of ``(keep, sanitized_doc)``.  If ``keep`` is False the
+            document should be skipped (e.g. duplicate).
+        """
+        result = doc.copy()
+
+        # 1. Field filtering (allowlist / denylist)
+        result = self._filter_fields(result)
+
+        # 2. Value masking
+        if self.mask_fields:
+            result = self._mask_values(result)
+
+        # 3. Trim & normalize strings
+        if self.trim or self.normalize_unicode or self.lowercase_fields:
+            result = self._normalize_strings(result)
+
+        # 4. PII redaction
+        if self.redact_pii:
+            result = self._redact_pii(result)
+
+        # 5. Deduplication (must be last — operates on final content)
+        if self.dedup:
+            if self._is_duplicate(result):
+                return False, result
+
+        return True, result
+
+    @property
+    def dedup_skipped(self) -> int:
+        """Number of documents skipped by deduplication."""
+        return self._dedup_count
+
+    def reset_dedup(self) -> None:
+        """Clear the dedup hash set (useful between batches / files)."""
+        self._seen_hashes.clear()
+        self._dedup_count = 0
+
+    # ------------------------------------------------------------------
+    # Internal steps
+    # ------------------------------------------------------------------
+
+    def _filter_fields(self, doc: Dict[str, Any]) -> Dict[str, Any]:
+        """Apply allowlist / denylist field filtering."""
+        if self.allow_fields is not None:
+            doc = {k: v for k, v in doc.items() if k in self.allow_fields}
+        if self.deny_fields:
+            doc = {k: v for k, v in doc.items() if k not in self.deny_fields}
+        return doc
+
+    def _mask_values(self, doc: Dict[str, Any]) -> Dict[str, Any]:
+        """Replace values of sensitive-named fields with mask token."""
+        for key in list(doc.keys()):
+            if key.lower() in self.mask_fields:
+                doc[key] = "******"
+        return doc
+
+    def _normalize_strings(self, doc: Dict[str, Any]) -> Dict[str, Any]:
+        """Trim, normalize unicode, and lowercase configured fields."""
+        for key, value in list(doc.items()):
+            if not isinstance(value, str):
+                continue
+            if self.trim:
+                value = value.strip()
+            if self.normalize_unicode:
+                value = unicodedata.normalize("NFC", value)
+            if key in self.lowercase_fields:
+                value = value.lower()
+            doc[key] = value
+        return doc
+
+    def _redact_pii(self, doc: Dict[str, Any]) -> Dict[str, Any]:
+        """Scan string values for PII patterns and replace with tokens."""
+        for key, value in list(doc.items()):
+            if not isinstance(value, str):
+                continue
+            for pii_name in self.pii_types:
+                pattern = PII_PATTERNS.get(pii_name)
+                if pattern is None:
+                    continue
+                token = _REDACT_TOKENS.get(pii_name, "[REDACTED]")
+                value = pattern.sub(token, value)
+            doc[key] = value
+        return doc
+
+    def _is_duplicate(self, doc: Dict[str, Any]) -> bool:
+        """Check if document content has already been seen."""
+        content_hash = hashlib.sha256(
+            json.dumps(doc, sort_keys=True, default=str).encode()
+        ).hexdigest()
+        if content_hash in self._seen_hashes:
+            self._dedup_count += 1
+            return True
+        self._seen_hashes.add(content_hash)
+        return False

--- a/tests/unit/core/test_ingest_pipeline_builder.py
+++ b/tests/unit/core/test_ingest_pipeline_builder.py
@@ -1,0 +1,259 @@
+"""
+Unit tests for the IngestPipelineBuilder.
+
+Tests the fluent builder API, processor chaining, on_failure routing,
+and the final build() output structure.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+from elastro.core.ingest.pipeline_builder import IngestPipelineBuilder
+
+
+class TestBuilderMetadata:
+    def test_pipeline_id(self) -> None:
+        builder = IngestPipelineBuilder("test-pipe")
+        assert builder.pipeline_id == "test-pipe"
+
+    def test_description(self) -> None:
+        body = IngestPipelineBuilder("p").description("Parse web logs").build()
+        assert body["description"] == "Parse web logs"
+
+    def test_empty_pipeline(self) -> None:
+        body = IngestPipelineBuilder("p").build()
+        assert body["processors"] == []
+        assert "on_failure" not in body
+
+
+class TestProcessors:
+    def test_grok(self) -> None:
+        body = (
+            IngestPipelineBuilder("p").grok("message", ["%{COMBINEDAPACHELOG}"]).build()
+        )
+        proc = body["processors"][0]["grok"]
+        assert proc["field"] == "message"
+        assert proc["patterns"] == ["%{COMBINEDAPACHELOG}"]
+
+    def test_grok_ignore_missing(self) -> None:
+        body = (
+            IngestPipelineBuilder("p")
+            .grok("msg", ["%{IP:ip}"], ignore_missing=True)
+            .build()
+        )
+        assert body["processors"][0]["grok"]["ignore_missing"] is True
+
+    def test_date(self) -> None:
+        body = (
+            IngestPipelineBuilder("p")
+            .date("ts", ["ISO8601"], target_field="event.time")
+            .build()
+        )
+        proc = body["processors"][0]["date"]
+        assert proc["field"] == "ts"
+        assert proc["formats"] == ["ISO8601"]
+        assert proc["target_field"] == "event.time"
+
+    def test_date_with_timezone(self) -> None:
+        body = (
+            IngestPipelineBuilder("p").date("ts", ["ISO8601"], timezone="UTC").build()
+        )
+        assert body["processors"][0]["date"]["timezone"] == "UTC"
+
+    def test_rename(self) -> None:
+        body = IngestPipelineBuilder("p").rename("old_field", "new_field").build()
+        proc = body["processors"][0]["rename"]
+        assert proc["field"] == "old_field"
+        assert proc["target_field"] == "new_field"
+
+    def test_remove(self) -> None:
+        body = (
+            IngestPipelineBuilder("p").remove("temp_field", ignore_missing=True).build()
+        )
+        proc = body["processors"][0]["remove"]
+        assert proc["field"] == "temp_field"
+        assert proc["ignore_missing"] is True
+
+    def test_convert(self) -> None:
+        body = IngestPipelineBuilder("p").convert("status", "integer").build()
+        proc = body["processors"][0]["convert"]
+        assert proc["field"] == "status"
+        assert proc["type"] == "integer"
+
+    def test_convert_with_target(self) -> None:
+        body = (
+            IngestPipelineBuilder("p")
+            .convert("bytes", "long", target_field="bytes_long")
+            .build()
+        )
+        assert body["processors"][0]["convert"]["target_field"] == "bytes_long"
+
+    def test_lowercase(self) -> None:
+        body = IngestPipelineBuilder("p").lowercase("method").build()
+        assert body["processors"][0]["lowercase"]["field"] == "method"
+
+    def test_uppercase(self) -> None:
+        body = IngestPipelineBuilder("p").uppercase("code").build()
+        assert body["processors"][0]["uppercase"]["field"] == "code"
+
+    def test_set_field(self) -> None:
+        body = IngestPipelineBuilder("p").set_field("env", "production").build()
+        proc = body["processors"][0]["set"]
+        assert proc["field"] == "env"
+        assert proc["value"] == "production"
+
+    def test_gsub(self) -> None:
+        body = IngestPipelineBuilder("p").gsub("message", r"\s+", " ").build()
+        proc = body["processors"][0]["gsub"]
+        assert proc["field"] == "message"
+        assert proc["pattern"] == r"\s+"
+        assert proc["replacement"] == " "
+
+    def test_geoip(self) -> None:
+        body = IngestPipelineBuilder("p").geoip("client_ip").build()
+        proc = body["processors"][0]["geoip"]
+        assert proc["field"] == "client_ip"
+        assert proc["ignore_missing"] is True
+
+    def test_redact(self) -> None:
+        body = (
+            IngestPipelineBuilder("p")
+            .redact("message", ["%{EMAILADDRESS:REDACTED}"])
+            .build()
+        )
+        proc = body["processors"][0]["redact"]
+        assert proc["field"] == "message"
+        assert len(proc["patterns"]) == 1
+
+    def test_dissect(self) -> None:
+        body = (
+            IngestPipelineBuilder("p").dissect("log", "%{ts} %{level} %{msg}").build()
+        )
+        proc = body["processors"][0]["dissect"]
+        assert proc["field"] == "log"
+        assert proc["pattern"] == "%{ts} %{level} %{msg}"
+
+    def test_script(self) -> None:
+        body = IngestPipelineBuilder("p").script("ctx.total = ctx.a + ctx.b").build()
+        proc = body["processors"][0]["script"]
+        assert proc["lang"] == "painless"
+        assert "ctx.total" in proc["source"]
+
+    def test_inference(self) -> None:
+        body = (
+            IngestPipelineBuilder("p")
+            .inference(
+                "my-model",
+                field_map={"message": "text"},
+                target_field="ml",
+            )
+            .build()
+        )
+        proc = body["processors"][0]["inference"]
+        assert proc["model_id"] == "my-model"
+        assert proc["field_map"] == {"message": "text"}
+        assert proc["target_field"] == "ml"
+
+    def test_custom(self) -> None:
+        body = (
+            IngestPipelineBuilder("p")
+            .custom({"community_id": {"source_ip": "src"}})
+            .build()
+        )
+        assert body["processors"][0] == {"community_id": {"source_ip": "src"}}
+
+
+class TestProcessorCount:
+    def test_count(self) -> None:
+        builder = (
+            IngestPipelineBuilder("p")
+            .grok("msg", ["%{IP:ip}"])
+            .date("ts", ["ISO8601"])
+            .rename("a", "b")
+        )
+        assert builder.processor_count == 3
+
+
+class TestChaining:
+    def test_fluent_chain(self) -> None:
+        """All methods return self for chaining."""
+        body = (
+            IngestPipelineBuilder("web-logs")
+            .description("Parse and enrich web access logs")
+            .grok("message", ["%{COMBINEDAPACHELOG}"])
+            .date("timestamp", ["dd/MMM/yyyy:HH:mm:ss Z"])
+            .geoip("clientip")
+            .convert("response", "integer")
+            .rename("clientip", "client.ip")
+            .remove("message")
+            .on_failure("failed-web-logs")
+            .build()
+        )
+
+        assert len(body["processors"]) == 6
+        assert body["on_failure"] is not None
+        assert body["description"] == "Parse and enrich web access logs"
+
+        # Verify processor order is preserved
+        proc_types = [list(p.keys())[0] for p in body["processors"]]
+        assert proc_types == ["grok", "date", "geoip", "convert", "rename", "remove"]
+
+
+class TestOnFailure:
+    def test_on_failure_structure(self) -> None:
+        body = IngestPipelineBuilder("p").on_failure("dead-letters").build()
+        assert "on_failure" in body
+        assert len(body["on_failure"]) == 3
+
+        # First step routes to DLQ index
+        first = body["on_failure"][0]
+        assert first["set"]["field"] == "_index"
+        assert first["set"]["value"] == "dead-letters"
+
+    def test_no_on_failure_by_default(self) -> None:
+        body = IngestPipelineBuilder("p").grok("msg", ["."]).build()
+        assert "on_failure" not in body
+
+
+class TestDeploy:
+    def test_deploy_calls_put_pipeline(self) -> None:
+        mock_client = MagicMock()
+        mock_es = MagicMock()
+        mock_client.get_client.return_value = mock_es
+
+        builder = (
+            IngestPipelineBuilder("test-pipe")
+            .description("test")
+            .grok("msg", ["%{IP:ip}"])
+        )
+        builder.deploy(mock_client)
+
+        mock_es.ingest.put_pipeline.assert_called_once()
+        call_kwargs = mock_es.ingest.put_pipeline.call_args
+        assert call_kwargs[1]["id"] == "test-pipe"
+
+    def test_deploy_with_override_id(self) -> None:
+        mock_client = MagicMock()
+        mock_es = MagicMock()
+        mock_client.get_client.return_value = mock_es
+
+        builder = IngestPipelineBuilder("original-id")
+        builder.deploy(mock_client, pipeline_id="override-id")
+
+        call_kwargs = mock_es.ingest.put_pipeline.call_args
+        assert call_kwargs[1]["id"] == "override-id"
+
+
+class TestBuildJSON:
+    def test_json_serializable(self) -> None:
+        """Build output must be JSON-serializable."""
+        body = (
+            IngestPipelineBuilder("p")
+            .grok("msg", ["%{IP:ip}"])
+            .date("ts", ["ISO8601"])
+            .on_failure("dlq")
+            .build()
+        )
+        # Should not raise
+        json_str = json.dumps(body)
+        assert json_str is not None

--- a/tests/unit/core/test_ingest_sanitizers.py
+++ b/tests/unit/core/test_ingest_sanitizers.py
@@ -1,0 +1,184 @@
+"""
+Unit tests for the SanitizationChain.
+
+Tests PII redaction, content deduplication, field filtering,
+value masking, and text normalization.
+"""
+
+from elastro.core.ingest.sanitizers import SanitizationChain
+
+
+class TestPIIRedaction:
+    def test_email_redaction(self) -> None:
+        chain = SanitizationChain(redact_pii=True)
+        keep, doc = chain.sanitize({"note": "Contact alice@example.com"})
+        assert keep is True
+        assert "[REDACTED_EMAIL]" in doc["note"]
+        assert "alice@example.com" not in doc["note"]
+
+    def test_ssn_redaction(self) -> None:
+        chain = SanitizationChain(redact_pii=True)
+        _, doc = chain.sanitize({"data": "SSN: 123-45-6789"})
+        assert "[REDACTED_SSN]" in doc["data"]
+        assert "123-45-6789" not in doc["data"]
+
+    def test_credit_card_redaction(self) -> None:
+        chain = SanitizationChain(redact_pii=True)
+        _, doc = chain.sanitize({"info": "Card: 4111 1111 1111 1111"})
+        assert "[REDACTED_CC]" in doc["info"]
+
+    def test_ipv4_redaction(self) -> None:
+        chain = SanitizationChain(redact_pii=True)
+        _, doc = chain.sanitize({"log": "Client IP: 192.168.1.100"})
+        assert "[REDACTED_IP]" in doc["log"]
+
+    def test_selective_pii_types(self) -> None:
+        """Only redact specified PII types."""
+        chain = SanitizationChain(redact_pii=True, pii_types=["email"])
+        _, doc = chain.sanitize({"msg": "Email: a@b.com, SSN: 123-45-6789"})
+        assert "[REDACTED_EMAIL]" in doc["msg"]
+        assert "123-45-6789" in doc["msg"]  # SSN not redacted
+
+    def test_non_string_values_untouched(self) -> None:
+        chain = SanitizationChain(redact_pii=True)
+        _, doc = chain.sanitize({"count": 42, "active": True})
+        assert doc["count"] == 42
+        assert doc["active"] is True
+
+    def test_no_pii_no_change(self) -> None:
+        chain = SanitizationChain(redact_pii=True)
+        _, doc = chain.sanitize({"name": "Alice", "age": 30})
+        assert doc["name"] == "Alice"
+
+
+class TestDeduplication:
+    def test_duplicate_skipped(self) -> None:
+        chain = SanitizationChain(dedup=True)
+
+        keep1, _ = chain.sanitize({"name": "Alice"})
+        keep2, _ = chain.sanitize({"name": "Alice"})
+        keep3, _ = chain.sanitize({"name": "Bob"})
+
+        assert keep1 is True
+        assert keep2 is False  # Duplicate
+        assert keep3 is True
+
+    def test_dedup_count(self) -> None:
+        chain = SanitizationChain(dedup=True)
+        chain.sanitize({"x": 1})
+        chain.sanitize({"x": 1})
+        chain.sanitize({"x": 1})
+        assert chain.dedup_skipped == 2
+
+    def test_reset_dedup(self) -> None:
+        chain = SanitizationChain(dedup=True)
+        chain.sanitize({"x": 1})
+        chain.sanitize({"x": 1})
+        assert chain.dedup_skipped == 1
+
+        chain.reset_dedup()
+        assert chain.dedup_skipped == 0
+
+        keep, _ = chain.sanitize({"x": 1})
+        assert keep is True  # No longer seen as duplicate
+
+    def test_order_independent_hashing(self) -> None:
+        """Documents with same fields in different order are deduped."""
+        chain = SanitizationChain(dedup=True)
+        keep1, _ = chain.sanitize({"a": 1, "b": 2})
+        keep2, _ = chain.sanitize({"b": 2, "a": 1})
+        assert keep1 is True
+        assert keep2 is False
+
+
+class TestFieldFiltering:
+    def test_allowlist(self) -> None:
+        chain = SanitizationChain(allow_fields=["name", "email"])
+        _, doc = chain.sanitize(
+            {"name": "Alice", "email": "a@b.com", "password": "secret"}
+        )
+        assert "name" in doc
+        assert "email" in doc
+        assert "password" not in doc
+
+    def test_denylist(self) -> None:
+        chain = SanitizationChain(deny_fields=["password", "secret"])
+        _, doc = chain.sanitize({"name": "Alice", "password": "123", "secret": "xyz"})
+        assert "name" in doc
+        assert "password" not in doc
+        assert "secret" not in doc
+
+    def test_allowlist_and_denylist(self) -> None:
+        """Allowlist is applied first, then denylist removes from the result."""
+        chain = SanitizationChain(
+            allow_fields=["a", "b", "c"],
+            deny_fields=["c"],
+        )
+        _, doc = chain.sanitize({"a": 1, "b": 2, "c": 3, "d": 4})
+        assert doc == {"a": 1, "b": 2}
+
+
+class TestValueMasking:
+    def test_mask_password(self) -> None:
+        chain = SanitizationChain(mask_fields=["password"])
+        _, doc = chain.sanitize({"name": "Alice", "password": "supersecret"})
+        assert doc["password"] == "******"
+        assert doc["name"] == "Alice"
+
+    def test_mask_case_insensitive(self) -> None:
+        chain = SanitizationChain(mask_fields=["TOKEN"])
+        _, doc = chain.sanitize({"token": "abc123"})
+        assert doc["token"] == "******"
+
+
+class TestTrimAndNormalize:
+    def test_trim_whitespace(self) -> None:
+        chain = SanitizationChain(trim=True)
+        _, doc = chain.sanitize({"name": "  Alice  ", "age": 30})
+        assert doc["name"] == "Alice"
+
+    def test_lowercase_fields(self) -> None:
+        chain = SanitizationChain(lowercase_fields=["status"])
+        _, doc = chain.sanitize({"status": "ACTIVE", "name": "Alice"})
+        assert doc["status"] == "active"
+        assert doc["name"] == "Alice"  # Unaffected
+
+    def test_trim_disabled(self) -> None:
+        chain = SanitizationChain(trim=False)
+        _, doc = chain.sanitize({"name": "  Alice  "})
+        assert doc["name"] == "  Alice  "
+
+
+class TestChainComposition:
+    def test_full_chain(self) -> None:
+        """All steps compose correctly in order."""
+        chain = SanitizationChain(
+            redact_pii=True,
+            dedup=True,
+            deny_fields=["secret"],
+            mask_fields=["password"],
+            trim=True,
+            lowercase_fields=["status"],
+        )
+
+        doc = {
+            "name": "  Alice  ",
+            "email": "Contact: alice@test.com",
+            "status": "ACTIVE",
+            "password": "s3cr3t",
+            "secret": "should-be-removed",
+        }
+
+        keep, result = chain.sanitize(doc)
+        assert keep is True
+        assert "secret" not in result  # Deny-listed
+        assert result["password"] == "******"  # Masked
+        assert result["name"] == "Alice"  # Trimmed
+        assert result["status"] == "active"  # Lowercased
+        assert "[REDACTED_EMAIL]" in result["email"]  # PII redacted
+
+    def test_does_not_mutate_original(self) -> None:
+        chain = SanitizationChain(trim=True, mask_fields=["pw"])
+        original = {"name": "  Bob  ", "pw": "pass"}
+        _, _ = chain.sanitize(original)
+        assert original["name"] == "  Bob  "  # Not mutated


### PR DESCRIPTION
Phase 2: Sanitization & Pipelines

1. sanitizers.py — SanitizationChain with 5 configurable steps:
   - PII redaction (email, SSN, phone, credit card, IPv4)
   - Content deduplication via SHA-256 hashing
   - Field filtering (allowlist / denylist)
   - Value masking for sensitive field names (passwords, tokens)
   - Trim & normalize (whitespace, unicode NFC, lowercase)

2. pipeline_builder.py — Fluent builder for ES ingest pipelines:
   - 13 processor methods: grok, date, geoip, convert, rename, remove, lowercase, uppercase, set, gsub, redact, dissect, script, inference
   - on_failure dead-letter index routing
   - deploy() to push to cluster, build() for JSON output

3. CLI: elastro ingest pipeline wizard
   - Interactive wizard walks through processor selection/configuration
   - JSON preview before deploy
   - Optional save-to-file if user declines deploy
   - Also adds 'pipeline create' and 'pipeline delete' commands

