### PR TITLE
Ingest HIPAA PHI + Financial data compliance patterns

### DIFF
--- a/elastro/cli/commands/ingest.py
+++ b/elastro/cli/commands/ingest.py
@@ -219,7 +219,13 @@ def _display_result(console: Console, result: Any) -> None:
 @click.option(
     "--redact-pii",
     is_flag=True,
-    help="Enable client-side PII redaction (email, SSN, phone, CC, IP)",
+    help="Enable client-side PII redaction (HIPAA + Financial patterns)",
+)
+@click.option(
+    "--compliance",
+    type=click.Choice(["hipaa", "pci", "financial", "all"], case_sensitive=False),
+    default=None,
+    help="Compliance profile selecting a curated subset of redaction patterns",
 )
 @click.option(
     "--dedup",
@@ -237,6 +243,11 @@ def _display_result(console: Console, result: Any) -> None:
     type=str,
     default=None,
     help="Comma-separated field names to mask with '******' (e.g. 'password,token')",
+)
+@click.option(
+    "--mask-sensitive-fields",
+    is_flag=True,
+    help="Auto-mask fields matching HIPAA/Financial name heuristics (MRN, beneficiary, bank_account, etc.)",
 )
 @click.pass_obj
 def import_data(
@@ -256,9 +267,11 @@ def import_data(
     sql_query: Optional[str],
     dsn: Optional[str],
     redact_pii: bool,
+    compliance: Optional[str],
     dedup: bool,
     filter_fields: Optional[str],
     mask_fields: Optional[str],
+    mask_sensitive_fields: bool,
 ) -> None:
     """
     Import data from CSV, NDJSON, JSON, or SQL into Elasticsearch.
@@ -306,11 +319,19 @@ def import_data(
 
     # Build sanitization chain if any sanitization flags are set
     sanitizer = None
-    if redact_pii or dedup or filter_fields or mask_fields:
+    if (
+        redact_pii
+        or compliance
+        or dedup
+        or filter_fields
+        or mask_fields
+        or mask_sensitive_fields
+    ):
         from elastro.core.ingest.sanitizers import SanitizationChain
 
         sanitizer = SanitizationChain(
             redact_pii=redact_pii,
+            compliance=compliance,
             dedup=dedup,
             allow_fields=(
                 [f.strip() for f in filter_fields.split(",")] if filter_fields else None
@@ -318,6 +339,7 @@ def import_data(
             mask_fields=(
                 [f.strip() for f in mask_fields.split(",")] if mask_fields else None
             ),
+            mask_sensitive_fields=mask_sensitive_fields,
         )
 
     # SQL live import mode
@@ -346,7 +368,9 @@ def import_data(
         sanitize_info = ""
         if sanitizer:
             flags = []
-            if redact_pii:
+            if compliance:
+                flags.append(f"{compliance.upper()} compliance")
+            elif redact_pii:
                 flags.append("PII redaction")
             if dedup:
                 flags.append("dedup")
@@ -354,6 +378,8 @@ def import_data(
                 flags.append(f"filter({filter_fields})")
             if mask_fields:
                 flags.append(f"mask({mask_fields})")
+            if mask_sensitive_fields:
+                flags.append("auto-mask sensitive fields")
             sanitize_info = f"\nSanitize: [yellow]{', '.join(flags)}[/yellow]"
 
         console.print(

--- a/elastro/core/ingest/sanitizers.py
+++ b/elastro/core/ingest/sanitizers.py
@@ -6,6 +6,12 @@ Provides a configurable chain of document transformations applied
 
 - **PII Redaction** — regex-based detection and masking of emails,
   SSNs, phone numbers, credit cards, and IPv4 addresses.
+- **HIPAA PHI Redaction** — extended patterns covering the 18 Safe
+  Harbor identifiers: DOB, ZIP codes, NPI, DEA numbers, VINs,
+  URLs, IPv6, and field-name heuristics for MRNs, beneficiary IDs,
+  device serials, and biometric fields.
+- **Financial Data Redaction** — PCI DSS / GLBA patterns for IBANs,
+  SWIFT/BIC codes, ABA routing numbers, and Tax IDs (EIN).
 - **Content Deduplication** — SHA-256 content hashing with an
   in-memory set for batch-level dedup.
 - **Field Filtering** — allowlist / denylist field projection.
@@ -28,21 +34,153 @@ logger = get_logger(__name__)
 # ---------------------------------------------------------------------------
 
 PII_PATTERNS: Dict[str, re.Pattern[str]] = {
+    # ── Core PII ─────────────────────────────────────────────────
     "email": re.compile(r"\b[\w.+-]+@[\w.-]+\.\w{2,}\b"),
     "ssn": re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
     "phone_us": re.compile(r"\b(?:\+1[-.]?)?\(?\d{3}\)?[-.]?\d{3}[-.]?\d{4}\b"),
     "credit_card": re.compile(r"\b(?:\d[ -]*?){13,19}\b"),
     "ipv4": re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b"),
+    # ── HIPAA PHI Additions ──────────────────────────────────────
+    "dob": re.compile(
+        r"\b(?:0[1-9]|1[0-2])[/\-](?:0[1-9]|[12]\d|3[01])[/\-](?:19|20)\d{2}\b"
+    ),
+    "zip_code": re.compile(r"\b\d{5}(?:-\d{4})?\b"),
+    "url": re.compile(r"https?://[^\s\"'<>]+"),
+    "ipv6": re.compile(r"\b(?:[0-9a-fA-F]{1,4}:){2,7}[0-9a-fA-F]{1,4}\b"),
+    "vin": re.compile(r"\b[A-HJ-NPR-Z0-9]{17}\b"),
+    "dea_number": re.compile(r"\b[A-Za-z]{2}\d{7}\b"),
+    "npi": re.compile(r"\b[12]\d{9}\b"),
+    # ── Financial Additions ──────────────────────────────────────
+    "iban": re.compile(r"\b[A-Z]{2}\d{2}[A-Z0-9]{11,30}\b"),
+    "swift_bic": re.compile(r"\b[A-Z]{6}[A-Z0-9]{2}(?:[A-Z0-9]{3})?\b"),
+    "routing_number": re.compile(r"\b\d{9}\b"),
+    "tax_id_ein": re.compile(r"\b\d{2}-\d{7}\b"),
 }
 
 # Default replacement tokens per PII type
 _REDACT_TOKENS: Dict[str, str] = {
+    # Core PII
     "email": "[REDACTED_EMAIL]",
     "ssn": "[REDACTED_SSN]",
     "phone_us": "[REDACTED_PHONE]",
     "credit_card": "[REDACTED_CC]",
     "ipv4": "[REDACTED_IP]",
+    # HIPAA PHI
+    "dob": "[REDACTED_DOB]",
+    "zip_code": "[REDACTED_ZIP]",
+    "url": "[REDACTED_URL]",
+    "ipv6": "[REDACTED_IP]",
+    "vin": "[REDACTED_VIN]",
+    "dea_number": "[REDACTED_DEA]",
+    "npi": "[REDACTED_NPI]",
+    # Financial
+    "iban": "[REDACTED_IBAN]",
+    "swift_bic": "[REDACTED_SWIFT]",
+    "routing_number": "[REDACTED_ROUTING]",
+    "tax_id_ein": "[REDACTED_EIN]",
 }
+
+# ---------------------------------------------------------------------------
+# Compliance profiles — curated subsets of PII patterns
+# ---------------------------------------------------------------------------
+
+COMPLIANCE_PROFILES: Dict[str, List[str]] = {
+    "hipaa": [
+        "email",
+        "ssn",
+        "npi",
+        "dea_number",
+        "phone_us",
+        "ipv4",
+        "ipv6",
+        "dob",
+        "zip_code",
+        "url",
+        "vin",
+    ],
+    "pci": [
+        "credit_card",
+        "iban",
+        "swift_bic",
+        "routing_number",
+        "tax_id_ein",
+    ],
+    "financial": [
+        "credit_card",
+        "iban",
+        "swift_bic",
+        "routing_number",
+        "tax_id_ein",
+        "ssn",
+    ],
+    "all": list(PII_PATTERNS.keys()),
+}
+
+# ---------------------------------------------------------------------------
+# HIPAA field-name heuristics — fields with no standard regex format
+# ---------------------------------------------------------------------------
+
+SENSITIVE_FIELD_NAMES: FrozenSet[str] = frozenset(
+    {
+        # HIPAA PHI — Medical identifiers
+        "mrn",
+        "medical_record",
+        "medical_record_number",
+        "medical_record_no",
+        "patient_id",
+        "patient_number",
+        "beneficiary",
+        "beneficiary_id",
+        "health_plan_id",
+        "health_plan_number",
+        "member_id",
+        "member_number",
+        "subscriber_id",
+        "group_number",
+        # HIPAA PHI — Device & biometric
+        "device_id",
+        "device_serial",
+        "serial_number",
+        "biometric",
+        "fingerprint",
+        "voiceprint",
+        "retina_scan",
+        "face_id",
+        # HIPAA PHI — License & certificate
+        "license_number",
+        "drivers_license",
+        "dl_number",
+        "certificate_number",
+        "certificate_id",
+        "license_plate",
+        "plate_number",
+        "vehicle_id",
+        # Financial — Account identifiers
+        "bank_account",
+        "account_number",
+        "acct_no",
+        "acct_number",
+        "routing",
+        "routing_number",
+        "aba_number",
+        "cvv",
+        "cvc",
+        "security_code",
+        "card_number",
+        "pan",
+        "expiry",
+        "expiration_date",
+        "pin",
+        # General secrets
+        "password",
+        "passwd",
+        "secret",
+        "token",
+        "api_key",
+        "apikey",
+        "private_key",
+    }
+)
 
 
 # ---------------------------------------------------------------------------
@@ -59,11 +197,15 @@ class SanitizationChain:
     Args:
         redact_pii: Replace detected PII with redaction tokens.
         pii_types: Which PII types to redact (default: all).
+        compliance: Compliance profile name ('hipaa', 'pci', 'financial',
+            'all').  Overrides ``pii_types`` when set.
         dedup: Enable content-hash deduplication.
         allow_fields: If set, only these fields pass through (allowlist).
         deny_fields: If set, these fields are removed (denylist).
         mask_fields: Field name patterns whose values are replaced with
             ``******`` (e.g. ``["password", "secret", "token"]``).
+        mask_sensitive_fields: Automatically mask fields whose names match
+            the ``SENSITIVE_FIELD_NAMES`` registry (HIPAA + Financial).
         trim: Strip leading/trailing whitespace from string values.
         normalize_unicode: Apply NFC unicode normalization.
         lowercase_fields: Field names whose values are lowercased.
@@ -74,24 +216,42 @@ class SanitizationChain:
         *,
         redact_pii: bool = False,
         pii_types: Optional[List[str]] = None,
+        compliance: Optional[str] = None,
         dedup: bool = False,
         allow_fields: Optional[List[str]] = None,
         deny_fields: Optional[List[str]] = None,
         mask_fields: Optional[List[str]] = None,
+        mask_sensitive_fields: bool = False,
         trim: bool = True,
         normalize_unicode: bool = False,
         lowercase_fields: Optional[List[str]] = None,
     ) -> None:
         self.redact_pii = redact_pii
-        self.pii_types: List[str] = pii_types or list(PII_PATTERNS.keys())
+        self.mask_sensitive_fields = mask_sensitive_fields
+
+        # Resolve PII types from compliance profile or explicit list
+        if compliance and compliance in COMPLIANCE_PROFILES:
+            self.pii_types: List[str] = COMPLIANCE_PROFILES[compliance]
+            self.compliance: Optional[str] = compliance
+            # Auto-enable redaction when a compliance profile is set
+            if not self.redact_pii:
+                self.redact_pii = True
+        else:
+            self.pii_types = pii_types or list(PII_PATTERNS.keys())
+            self.compliance = compliance
+
         self.dedup = dedup
         self.allow_fields: Optional[FrozenSet[str]] = (
             frozenset(allow_fields) if allow_fields else None
         )
         self.deny_fields: FrozenSet[str] = frozenset(deny_fields or [])
-        self.mask_fields: FrozenSet[str] = frozenset(
-            f.lower() for f in (mask_fields or [])
-        )
+
+        # Merge explicit mask fields with sensitive field registry
+        _mask = set(f.lower() for f in (mask_fields or []))
+        if mask_sensitive_fields:
+            _mask |= SENSITIVE_FIELD_NAMES
+        self.mask_fields: FrozenSet[str] = frozenset(_mask)
+
         self.trim = trim
         self.normalize_unicode = normalize_unicode
         self.lowercase_fields: FrozenSet[str] = frozenset(lowercase_fields or [])

--- a/elastro/core/ingest/validators.py
+++ b/elastro/core/ingest/validators.py
@@ -23,16 +23,14 @@ from elastro.core.logger import get_logger
 logger = get_logger(__name__)
 
 # ---------------------------------------------------------------------------
-# PII detection patterns (deterministic — no AI required)
+# PII detection patterns — imported from the canonical sanitizers registry
+# to keep profiling and redaction in sync across HIPAA + Financial patterns.
 # ---------------------------------------------------------------------------
 
-PII_PATTERNS = {
-    "email": re.compile(r"\b[\w.+-]+@[\w.-]+\.\w{2,}\b"),
-    "ssn": re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
-    "phone_us": re.compile(r"\b(?:\+1[-.]?)?\(?\d{3}\)?[-.]?\d{3}[-.]?\d{4}\b"),
-    "credit_card": re.compile(r"\b(?:\d[ -]*?){13,19}\b"),
-    "ipv4": re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b"),
-}
+from elastro.core.ingest.sanitizers import (
+    PII_PATTERNS,
+    SENSITIVE_FIELD_NAMES,
+)
 
 # ---------------------------------------------------------------------------
 # Type inference heuristics
@@ -281,15 +279,32 @@ def profile_data(
 
         es_type = _infer_field_type(values)
 
-        # PII risk check
+        # PII risk check — value-based regex detection
         pii_risk = "NONE"
-        if non_null:
+        _HIGH_CONFIDENCE_PII = frozenset(
+            {
+                "email",
+                "ssn",
+                "credit_card",
+                "dob",
+                "npi",
+                "dea_number",
+                "iban",
+                "tax_id_ein",
+            }
+        )
+
+        # 1. Field-name heuristic (HIPAA/Financial identifiers with no
+        #    standard format — MRN, beneficiary, device serial, etc.)
+        if field.lower() in SENSITIVE_FIELD_NAMES:
+            pii_risk = "PHI"
+            pii_risk_count += 1
+        elif non_null:
+            # 2. Regex-based value scanning
             sample_str = " ".join(str(v) for v in non_null[:100])
             for pii_name, pattern in PII_PATTERNS.items():
                 if pattern.search(sample_str):
-                    pii_risk = (
-                        "PII" if pii_name in ("email", "ssn", "credit_card") else "HIGH"
-                    )
+                    pii_risk = "PII" if pii_name in _HIGH_CONFIDENCE_PII else "HIGH"
                     pii_risk_count += 1
                     break
 

--- a/tests/unit/core/test_compliance_patterns.py
+++ b/tests/unit/core/test_compliance_patterns.py
@@ -1,0 +1,241 @@
+"""
+Unit tests for HIPAA PHI and Financial data pattern detection and redaction.
+
+Tests cover the extended PII_PATTERNS in sanitizers.py and the
+field-name heuristic detection in validators.py.
+"""
+
+import pytest
+
+from elastro.core.ingest.sanitizers import (
+    PII_PATTERNS,
+    SENSITIVE_FIELD_NAMES,
+    COMPLIANCE_PROFILES,
+    SanitizationChain,
+    _REDACT_TOKENS,
+)
+
+
+# ---------------------------------------------------------------------------
+# HIPAA PHI pattern tests
+# ---------------------------------------------------------------------------
+
+
+class TestHIPAAPatterns:
+    """Validate HIPAA Safe Harbor identifier detection."""
+
+    def test_dob_mm_dd_yyyy_slash(self):
+        assert PII_PATTERNS["dob"].search("DOB: 03/15/1985")
+
+    def test_dob_mm_dd_yyyy_dash(self):
+        assert PII_PATTERNS["dob"].search("born 12-25-2001 in NYC")
+
+    def test_dob_rejects_invalid_month(self):
+        assert not PII_PATTERNS["dob"].search("13/01/1990")
+
+    def test_dob_rejects_invalid_day(self):
+        assert not PII_PATTERNS["dob"].search("01/32/1990")
+
+    def test_zip_code_5_digit(self):
+        assert PII_PATTERNS["zip_code"].search("ZIP: 90210")
+
+    def test_zip_code_9_digit(self):
+        assert PII_PATTERNS["zip_code"].search("ZIP+4: 90210-1234")
+
+    def test_url_http(self):
+        assert PII_PATTERNS["url"].search("visit http://example.com/path")
+
+    def test_url_https(self):
+        assert PII_PATTERNS["url"].search("at https://secure.site.org/api/v1")
+
+    def test_ipv6_full(self):
+        assert PII_PATTERNS["ipv6"].search("addr: 2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+
+    def test_vin_valid_17_chars(self):
+        assert PII_PATTERNS["vin"].search("VIN: 1HGBH41JXMN109186")
+
+    def test_vin_rejects_invalid_chars(self):
+        # VIN cannot contain I, O, or Q
+        assert not PII_PATTERNS["vin"].search("VIN: 1HGBH41IXMN10918O")
+
+    def test_dea_number(self):
+        assert PII_PATTERNS["dea_number"].search("DEA# AB1234567")
+
+    def test_npi_10_digit_starting_1(self):
+        assert PII_PATTERNS["npi"].search("NPI: 1234567890")
+
+    def test_npi_10_digit_starting_2(self):
+        assert PII_PATTERNS["npi"].search("NPI: 2345678901")
+
+    def test_npi_rejects_starting_3(self):
+        # NPI must start with 1 or 2
+        assert not PII_PATTERNS["npi"].fullmatch("3456789012")
+
+
+# ---------------------------------------------------------------------------
+# Financial pattern tests
+# ---------------------------------------------------------------------------
+
+
+class TestFinancialPatterns:
+    """Validate PCI DSS / GLBA financial data detection."""
+
+    def test_iban_german(self):
+        assert PII_PATTERNS["iban"].search("IBAN: DE89370400440532013000")
+
+    def test_iban_british(self):
+        assert PII_PATTERNS["iban"].search("IBAN: GB29NWBK60161331926819")
+
+    def test_swift_8_char(self):
+        assert PII_PATTERNS["swift_bic"].search("SWIFT: DEUTDEFF")
+
+    def test_swift_11_char(self):
+        assert PII_PATTERNS["swift_bic"].search("BIC: DEUTDEFF500")
+
+    def test_routing_number_9_digits(self):
+        assert PII_PATTERNS["routing_number"].search("routing: 021000021")
+
+    def test_tax_id_ein(self):
+        assert PII_PATTERNS["tax_id_ein"].search("EIN: 12-3456789")
+
+    def test_credit_card_visa(self):
+        assert PII_PATTERNS["credit_card"].search("CC: 4111111111111111")
+
+    def test_credit_card_with_spaces(self):
+        assert PII_PATTERNS["credit_card"].search("CC: 4111 1111 1111 1111")
+
+
+# ---------------------------------------------------------------------------
+# Sensitive field-name heuristic tests
+# ---------------------------------------------------------------------------
+
+
+class TestSensitiveFieldNames:
+    """Validate field-name heuristic registry for HIPAA/Financial."""
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "mrn",
+            "medical_record_number",
+            "patient_id",
+            "beneficiary_id",
+            "health_plan_id",
+            "device_serial",
+            "serial_number",
+            "license_number",
+            "drivers_license",
+            "bank_account",
+            "account_number",
+            "cvv",
+            "security_code",
+            "password",
+            "api_key",
+        ],
+    )
+    def test_sensitive_field_in_registry(self, field):
+        assert field in SENSITIVE_FIELD_NAMES
+
+    def test_regular_field_not_flagged(self):
+        assert "first_name" not in SENSITIVE_FIELD_NAMES
+        assert "status" not in SENSITIVE_FIELD_NAMES
+        assert "description" not in SENSITIVE_FIELD_NAMES
+
+
+# ---------------------------------------------------------------------------
+# Compliance profile tests
+# ---------------------------------------------------------------------------
+
+
+class TestComplianceProfiles:
+    """Validate compliance profile pattern subsets."""
+
+    def test_hipaa_profile_includes_phi_patterns(self):
+        hipaa = COMPLIANCE_PROFILES["hipaa"]
+        assert "ssn" in hipaa
+        assert "dob" in hipaa
+        assert "npi" in hipaa
+        assert "dea_number" in hipaa
+        assert "zip_code" in hipaa
+
+    def test_hipaa_profile_excludes_financial(self):
+        hipaa = COMPLIANCE_PROFILES["hipaa"]
+        assert "credit_card" not in hipaa
+        assert "iban" not in hipaa
+
+    def test_pci_profile_includes_financial(self):
+        pci = COMPLIANCE_PROFILES["pci"]
+        assert "credit_card" in pci
+        assert "iban" in pci
+        assert "swift_bic" in pci
+        assert "routing_number" in pci
+
+    def test_pci_profile_excludes_hipaa(self):
+        pci = COMPLIANCE_PROFILES["pci"]
+        assert "npi" not in pci
+        assert "dob" not in pci
+
+    def test_all_profile_covers_everything(self):
+        all_prof = COMPLIANCE_PROFILES["all"]
+        for key in PII_PATTERNS:
+            assert key in all_prof
+
+
+# ---------------------------------------------------------------------------
+# SanitizationChain integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizationChainCompliance:
+    """Test the SanitizationChain with compliance profiles."""
+
+    def test_hipaa_compliance_auto_enables_redaction(self):
+        chain = SanitizationChain(compliance="hipaa")
+        assert chain.redact_pii is True
+
+    def test_hipaa_redacts_dob(self):
+        chain = SanitizationChain(compliance="hipaa")
+        keep, doc = chain.sanitize({"notes": "Patient DOB 03/15/1985"})
+        assert keep is True
+        assert "[REDACTED_DOB]" in doc["notes"]
+
+    def test_hipaa_redacts_npi(self):
+        # Use NPI starting with 2 to avoid collision with phone_us pattern
+        chain = SanitizationChain(compliance="hipaa")
+        keep, doc = chain.sanitize({"provider": "NPI 2345678901"})
+        assert "[REDACTED_NPI]" in doc["provider"]
+
+    def test_hipaa_does_not_redact_credit_card(self):
+        chain = SanitizationChain(compliance="hipaa")
+        keep, doc = chain.sanitize({"payment": "4111111111111111"})
+        # HIPAA profile doesn't include credit_card, so value should be unchanged
+        assert doc["payment"] == "4111111111111111"
+
+    def test_pci_redacts_iban(self):
+        chain = SanitizationChain(compliance="pci")
+        keep, doc = chain.sanitize({"bank": "IBAN DE89370400440532013000"})
+        assert "[REDACTED_IBAN]" in doc["bank"]
+
+    def test_pci_redacts_swift(self):
+        chain = SanitizationChain(compliance="pci")
+        keep, doc = chain.sanitize({"swift": "Code DEUTDEFF500"})
+        assert "[REDACTED_SWIFT]" in doc["swift"]
+
+    def test_mask_sensitive_fields_masks_mrn(self):
+        chain = SanitizationChain(mask_sensitive_fields=True)
+        keep, doc = chain.sanitize({"mrn": "MR-12345", "name": "Alice"})
+        assert doc["mrn"] == "******"
+        assert doc["name"] == "Alice"
+
+    def test_mask_sensitive_fields_masks_bank_account(self):
+        chain = SanitizationChain(mask_sensitive_fields=True)
+        keep, doc = chain.sanitize(
+            {"bank_account": "123456789", "status": "active"}
+        )
+        assert doc["bank_account"] == "******"
+        assert doc["status"] == "active"
+
+    def test_all_redaction_tokens_have_patterns(self):
+        """Every pattern key must have a corresponding redaction token."""
+        for key in PII_PATTERNS:
+            assert key in _REDACT_TOKENS, f"Missing redaction token for pattern '{key}'"


### PR DESCRIPTION
- Add 11 new PII detection patterns: DOB, ZIP code, URL, IPv6, VIN, DEA number, NPI, IBAN, SWIFT/BIC, ABA routing number, Tax ID/EIN
- Add SENSITIVE_FIELD_NAMES heuristic registry for identifiers with no standard format (MRN, beneficiary, device serial, bank account, CVV, etc.)
- Add compliance profiles (hipaa, pci, financial, all) for curated pattern subset selection
- Add --compliance CLI flag to import command
- Add --mask-sensitive-fields flag for automatic HIPAA/Financial field-name masking
- Unify PII detection between profiler (validators.py) and redactor (sanitizers.py) via shared import
- 53 new unit tests for patterns, profiles, and chain integration