### PR TITLE
feat(esql): Native ES|QL fluent builder + CLI commands

### DIFF
--- a/elastro/cli/cli.py
+++ b/elastro/cli/cli.py
@@ -111,6 +111,7 @@ from elastro.cli.commands.painless_commands import painless_group
 from elastro.cli.commands.telemetry import telemetry_group
 from elastro.cli.commands.memory import memory_group
 from elastro.cli.commands.tools import tools_group
+from elastro.cli.commands.esql import esql_group
 
 # Register Top-Level Groups
 
@@ -294,6 +295,7 @@ cli.add_command(tools_group)
 cli.add_command(gui)
 cli.add_command(rag_group)
 cli.add_command(daemon_group)
+cli.add_command(esql_group)
 
 
 def main() -> None:

--- a/elastro/cli/commands/esql.py
+++ b/elastro/cli/commands/esql.py
@@ -1,0 +1,379 @@
+"""
+CLI commands for ES|QL query execution.
+
+Provides:
+- ``elastro esql query`` — execute an ES|QL query string or file
+- ``elastro esql build`` — interactively build an ES|QL query using the fluent API
+"""
+
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+import rich_click as click
+from rich.console import Console
+from rich.panel import Panel
+from rich.syntax import Syntax
+from rich.table import Table
+from rich import box
+
+from elastro.core.client import ElasticsearchClient
+
+
+@click.group("esql")
+def esql_group() -> None:
+    """
+    ES|QL query builder and executor.
+
+    Execute ES|QL queries against Elasticsearch with rich output
+    formatting and a fluent query builder.
+    """
+    pass
+
+
+@esql_group.command("query")
+@click.argument("query_string", required=False)
+@click.option(
+    "--file",
+    "-f",
+    "query_file",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False),
+    help="Path to a .esql file containing the query",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "json", "csv", "raw"], case_sensitive=False),
+    default="table",
+    help="Output format (default: table)",
+)
+@click.option(
+    "--columnar",
+    is_flag=True,
+    help="Return results in columnar format",
+)
+@click.option(
+    "--limit",
+    "-n",
+    type=int,
+    default=None,
+    help="Override LIMIT in the query (appends if not present)",
+)
+@click.option(
+    "--save",
+    type=click.Path(file_okay=True, dir_okay=False),
+    default=None,
+    help="Save results to a file (JSON or CSV based on extension)",
+)
+@click.pass_obj
+def esql_query(
+    client: ElasticsearchClient,
+    query_string: Optional[str],
+    query_file: Optional[str],
+    output_format: str,
+    columnar: bool,
+    limit: Optional[int],
+    save: Optional[str],
+) -> None:
+    """
+    Execute an ES|QL query.
+
+    Pass a query string directly or use --file to load from disk.
+
+    Examples:
+
+    ```bash
+    elastro esql query "FROM logs-* | WHERE status >= 400 | LIMIT 10"
+    ```
+
+    ```bash
+    elastro esql query --file my_query.esql --format json
+    ```
+
+    Pipe-friendly with --format csv:
+    ```bash
+    elastro esql query "FROM metrics-* | STATS avg(cpu) BY host" --format csv
+    ```
+    """
+    console = Console()
+
+    # Resolve query source
+    if query_file:
+        query_text = Path(query_file).read_text(encoding="utf-8").strip()
+    elif query_string:
+        query_text = query_string.strip()
+    else:
+        # Read from stdin if piped
+        if not sys.stdin.isatty():
+            query_text = sys.stdin.read().strip()
+        else:
+            console.print(
+                "[bold red]Error:[/bold red] Provide a query string, --file, or pipe via stdin."
+            )
+            raise SystemExit(1)
+
+    if not query_text:
+        console.print("[bold red]Error:[/bold red] Empty query.")
+        raise SystemExit(1)
+
+    # Append limit override if requested
+    if limit is not None:
+        # Remove existing LIMIT if present, then append
+        lines = query_text.split("|")
+        lines = [l.strip() for l in lines if not l.strip().upper().startswith("LIMIT")]
+        lines.append(f"LIMIT {limit}")
+        query_text = " | ".join(lines)
+
+    # Display the query being executed
+    console.print(
+        Panel(
+            Syntax(query_text, "sql", theme="monokai", word_wrap=True),
+            title="[bold cyan]ES|QL Query[/bold cyan]",
+            border_style="cyan",
+            padding=(0, 1),
+        )
+    )
+
+    # Execute
+    try:
+        body = {"query": query_text}
+        if columnar:
+            body["columnar"] = True
+
+        response = client._client.esql.query(body=body)
+
+        # Handle ObjectApiResponse
+        if hasattr(response, "body"):
+            result = response.body
+        elif isinstance(response, dict):
+            result = response
+        else:
+            result = response
+
+    except AttributeError:
+        # Fallback for older elasticsearch-py without esql namespace
+        try:
+            response = client._client.perform_request(
+                "POST",
+                "/_query",
+                body={"query": query_text, **({"columnar": True} if columnar else {})},
+            )
+            result = response if isinstance(response, dict) else json.loads(response)
+        except Exception as e:
+            console.print(
+                f"[bold red]Error:[/bold red] ES|QL requires Elasticsearch 8.11+. {e}"
+            )
+            raise SystemExit(1)
+    except Exception as e:
+        console.print(f"[bold red]Query failed:[/bold red] {e}")
+        raise SystemExit(1)
+
+    # Extract columns and values
+    columns = result.get("columns", [])
+    values = result.get("values", [])
+
+    col_names = [c.get("name", f"col_{i}") for i, c in enumerate(columns)]
+
+    if not values:
+        console.print("[dim]No results returned.[/dim]")
+        return
+
+    # Format output
+    if output_format == "table":
+        _render_table(console, col_names, values)
+    elif output_format == "json":
+        _render_json(console, col_names, values)
+    elif output_format == "csv":
+        _render_csv(col_names, values)
+    elif output_format == "raw":
+        console.print_json(json.dumps(result, default=str))
+
+    # Summary
+    console.print(
+        f"\n[dim]{len(values)} row(s) returned, {len(col_names)} column(s)[/dim]"
+    )
+
+    # Save to file
+    if save:
+        _save_results(save, col_names, values)
+        console.print(f"[green]Results saved to {save}[/green]")
+
+
+@esql_group.command("build")
+@click.option("--source", "-s", required=True, help="Index pattern for FROM clause")
+@click.option(
+    "--where",
+    "-w",
+    "where_clauses",
+    multiple=True,
+    help="WHERE condition(s) — can be repeated",
+)
+@click.option(
+    "--eval",
+    "-e",
+    "eval_exprs",
+    multiple=True,
+    help="EVAL expression(s) — can be repeated",
+)
+@click.option(
+    "--stats",
+    "stats_exprs",
+    multiple=True,
+    help="STATS aggregation(s) — can be repeated",
+)
+@click.option("--by", "stats_by", default=None, help="STATS ... BY field(s)")
+@click.option(
+    "--sort",
+    "sort_fields",
+    multiple=True,
+    help="SORT field(s) — can be repeated",
+)
+@click.option("--sort-order", type=click.Choice(["ASC", "DESC"]), default="ASC")
+@click.option("--keep", "keep_fields", multiple=True, help="KEEP field(s)")
+@click.option("--drop", "drop_fields", multiple=True, help="DROP field(s)")
+@click.option("--limit", "-n", type=int, default=None, help="LIMIT value")
+@click.option(
+    "--execute",
+    "-x",
+    is_flag=True,
+    help="Execute the built query immediately",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "json", "csv", "raw"], case_sensitive=False),
+    default="table",
+    help="Output format when --execute is used",
+)
+@click.pass_obj
+def esql_build(
+    client: ElasticsearchClient,
+    source: str,
+    where_clauses: tuple,
+    eval_exprs: tuple,
+    stats_exprs: tuple,
+    stats_by: Optional[str],
+    sort_fields: tuple,
+    sort_order: str,
+    keep_fields: tuple,
+    drop_fields: tuple,
+    limit: Optional[int],
+    execute: bool,
+    output_format: str,
+) -> None:
+    """
+    Build an ES|QL query using CLI flags.
+
+    Constructs a query using the fluent builder API and either
+    prints the rendered ES|QL or executes it directly.
+
+    Examples:
+
+    Build and print:
+    ```bash
+    elastro esql build -s "logs-*" -w "status >= 400" --stats "count = COUNT(*)" --by host --limit 10
+    ```
+
+    Build and execute:
+    ```bash
+    elastro esql build -s "logs-*" -w "status >= 400" --limit 5 --execute
+    ```
+    """
+    from elastro.core.esql import ESQLQuery
+
+    console = Console()
+
+    q = ESQLQuery(source)
+    for w in where_clauses:
+        q.where(w)
+    for e in eval_exprs:
+        q.eval(e)
+    if stats_exprs:
+        by = [b.strip() for b in stats_by.split(",")] if stats_by else None
+        q.stats(*stats_exprs, by=by)
+    for s in sort_fields:
+        q.sort(s, order=sort_order)
+    if keep_fields:
+        q.keep(*keep_fields)
+    if drop_fields:
+        q.drop(*drop_fields)
+    if limit is not None:
+        q.limit(limit)
+
+    query_text = q.build()
+
+    console.print(
+        Panel(
+            Syntax(query_text, "sql", theme="monokai", word_wrap=True),
+            title="[bold cyan]Built ES|QL Query[/bold cyan]",
+            border_style="cyan",
+            padding=(0, 1),
+        )
+    )
+
+    if execute:
+        # Re-invoke query execution
+        ctx = click.get_current_context()
+        ctx.invoke(
+            esql_query,
+            query_string=query_text,
+            query_file=None,
+            output_format=output_format,
+            columnar=False,
+            limit=None,
+            save=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Output renderers
+# ---------------------------------------------------------------------------
+
+
+def _render_table(console: Console, columns: list, values: list) -> None:
+    """Render results as a Rich table."""
+    table = Table(box=box.ROUNDED, show_lines=False, highlight=True)
+    for col in columns:
+        table.add_column(col, style="cyan", overflow="fold")
+
+    for row in values:
+        table.add_row(*(str(v) if v is not None else "[dim]null[/dim]" for v in row))
+
+    console.print(table)
+
+
+def _render_json(console: Console, columns: list, values: list) -> None:
+    """Render results as JSON array of objects."""
+    rows = [dict(zip(columns, row)) for row in values]
+    console.print_json(json.dumps(rows, default=str, indent=2))
+
+
+def _render_csv(columns: list, values: list) -> None:
+    """Render results as CSV to stdout (pipe-friendly)."""
+    import csv
+    import io
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(columns)
+    for row in values:
+        writer.writerow(row)
+    print(output.getvalue(), end="")
+
+
+def _save_results(path: str, columns: list, values: list) -> None:
+    """Save results to a file (JSON or CSV based on extension)."""
+    p = Path(path)
+    if p.suffix.lower() == ".csv":
+        import csv
+
+        with open(p, "w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(columns)
+            for row in values:
+                writer.writerow(row)
+    else:
+        rows = [dict(zip(columns, row)) for row in values]
+        with open(p, "w") as f:
+            json.dump(rows, f, indent=2, default=str)

--- a/elastro/core/esql/__init__.py
+++ b/elastro/core/esql/__init__.py
@@ -1,0 +1,11 @@
+"""
+ES|QL fluent query builder and renderer.
+
+Provides a Pythonic, pipe-based API for constructing ES|QL queries
+that mirrors the native ES|QL syntax while offering compile-time
+safety and composability.
+"""
+
+from elastro.core.esql.builder import ESQLQuery
+
+__all__ = ["ESQLQuery"]

--- a/elastro/core/esql/builder.py
+++ b/elastro/core/esql/builder.py
@@ -1,0 +1,309 @@
+"""
+Fluent ES|QL query builder.
+
+Constructs syntactically valid ES|QL query strings using a chainable
+Python API.  Each method appends a processing command to an internal
+pipeline that is rendered into ES|QL text via :meth:`build`.
+
+Usage::
+
+    from elastro.core.esql import ESQLQuery
+
+    q = (
+        ESQLQuery("logs-*")
+        .where("status_code >= 400")
+        .where("@timestamp > now() - 1h")
+        .stats("avg_response = AVG(response_time)", by="service.name")
+        .sort("avg_response", desc=True)
+        .limit(25)
+        .build()
+    )
+
+    # q == 'FROM logs-* | WHERE status_code >= 400 | WHERE @timestamp > now() - 1h | ...'
+
+The builder enforces structural correctness:
+
+- Exactly one source command (``FROM`` or ``ROW``) is required.
+- ``LIMIT`` must have a positive integer value.
+- ``build()`` produces the final query string.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+
+class ESQLQuery:
+    """Fluent builder for ES|QL queries.
+
+    Args:
+        source: Index pattern, data stream, or alias for the ``FROM``
+            command.  Pass ``None`` to use :meth:`row` instead.
+    """
+
+    def __init__(self, source: Optional[str] = None) -> None:
+        self._commands: List[str] = []
+        if source is not None:
+            self._commands.append(f"FROM {source}")
+
+    # ------------------------------------------------------------------
+    # Source commands
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_(cls, source: str, *, metadata: Optional[List[str]] = None) -> "ESQLQuery":
+        """Create a query starting with ``FROM``.
+
+        Args:
+            source: Index pattern (supports wildcards).
+            metadata: Optional metadata fields to include
+                (e.g. ``["_index", "_id"]``).
+        """
+        q = cls(source)
+        if metadata:
+            q._commands[-1] += f" METADATA {', '.join(metadata)}"
+        return q
+
+    @classmethod
+    def row(cls, **fields: Any) -> "ESQLQuery":
+        """Create a query starting with ``ROW``.
+
+        Each keyword argument becomes a ``field = value`` assignment.
+        String values are automatically quoted.
+        """
+        q = cls()
+        assignments = []
+        for k, v in fields.items():
+            assignments.append(f"{k} = {_format_value(v)}")
+        q._commands.append(f"ROW {', '.join(assignments)}")
+        return q
+
+    # ------------------------------------------------------------------
+    # Processing commands
+    # ------------------------------------------------------------------
+
+    def where(self, condition: str) -> "ESQLQuery":
+        """Append a ``WHERE`` filter condition.
+
+        Multiple calls are chained as separate ``WHERE`` commands
+        (equivalent to AND logic in ES|QL).
+        """
+        self._commands.append(f"WHERE {condition}")
+        return self
+
+    def eval(self, *expressions: str) -> "ESQLQuery":
+        """Append an ``EVAL`` command to create or transform columns.
+
+        Args:
+            expressions: One or more column expressions
+                (e.g. ``"rate = bytes / duration"``).
+        """
+        self._commands.append(f"EVAL {', '.join(expressions)}")
+        return self
+
+    def stats(
+        self,
+        *aggregations: str,
+        by: Optional[Union[str, List[str]]] = None,
+    ) -> "ESQLQuery":
+        """Append a ``STATS ... BY`` aggregation command.
+
+        Args:
+            aggregations: Aggregation expressions
+                (e.g. ``"avg_bytes = AVG(bytes)"``).
+            by: Group-by field(s).
+        """
+        cmd = f"STATS {', '.join(aggregations)}"
+        if by is not None:
+            if isinstance(by, str):
+                by = [by]
+            cmd += f" BY {', '.join(by)}"
+        self._commands.append(cmd)
+        return self
+
+    def sort(
+        self,
+        *fields: str,
+        desc: bool = False,
+        order: Optional[str] = None,
+    ) -> "ESQLQuery":
+        """Append a ``SORT`` command.
+
+        Args:
+            fields: Field names to sort by.
+            desc: Shorthand to sort descending (applied to all fields).
+            order: Explicit order string (``ASC`` or ``DESC``).
+                Overrides ``desc``.
+        """
+        direction = order or ("DESC" if desc else "ASC")
+        sorted_fields = [f"{f} {direction}" for f in fields]
+        self._commands.append(f"SORT {', '.join(sorted_fields)}")
+        return self
+
+    def limit(self, n: int) -> "ESQLQuery":
+        """Append a ``LIMIT`` command.
+
+        Args:
+            n: Maximum number of rows to return.
+
+        Raises:
+            ValueError: If *n* is not a positive integer.
+        """
+        if not isinstance(n, int) or n <= 0:
+            raise ValueError(f"LIMIT must be a positive integer, got {n!r}")
+        self._commands.append(f"LIMIT {n}")
+        return self
+
+    def keep(self, *fields: str) -> "ESQLQuery":
+        """Append a ``KEEP`` command to retain only specified columns."""
+        self._commands.append(f"KEEP {', '.join(fields)}")
+        return self
+
+    def drop(self, *fields: str) -> "ESQLQuery":
+        """Append a ``DROP`` command to remove specified columns."""
+        self._commands.append(f"DROP {', '.join(fields)}")
+        return self
+
+    def rename(self, **mappings: str) -> "ESQLQuery":
+        """Append a ``RENAME`` command.
+
+        Args:
+            mappings: ``old_name=new_name`` keyword arguments.
+        """
+        parts = [f"{old} AS {new}" for old, new in mappings.items()]
+        self._commands.append(f"RENAME {', '.join(parts)}")
+        return self
+
+    def dissect(
+        self, field: str, pattern: str, *, append_separator: Optional[str] = None
+    ) -> "ESQLQuery":
+        """Append a ``DISSECT`` command for text parsing.
+
+        Args:
+            field: Source field to parse.
+            pattern: Dissect pattern string.
+            append_separator: Optional append separator.
+        """
+        cmd = f'DISSECT {field} "{pattern}"'
+        if append_separator is not None:
+            cmd += f' APPEND_SEPARATOR="{append_separator}"'
+        self._commands.append(cmd)
+        return self
+
+    def grok(self, field: str, pattern: str) -> "ESQLQuery":
+        """Append a ``GROK`` command for pattern-based text extraction.
+
+        Args:
+            field: Source field to parse.
+            pattern: Grok pattern string.
+        """
+        self._commands.append(f'GROK {field} "{pattern}"')
+        return self
+
+    def enrich(
+        self,
+        policy: str,
+        *,
+        on: Optional[str] = None,
+        with_fields: Optional[List[str]] = None,
+    ) -> "ESQLQuery":
+        """Append an ``ENRICH`` command for data enrichment.
+
+        Args:
+            policy: Name of the enrich policy.
+            on: Match field.
+            with_fields: Fields to add from the enrich index.
+        """
+        cmd = f"ENRICH {policy}"
+        if on:
+            cmd += f" ON {on}"
+        if with_fields:
+            cmd += f" WITH {', '.join(with_fields)}"
+        self._commands.append(cmd)
+        return self
+
+    def mv_expand(self, field: str) -> "ESQLQuery":
+        """Append an ``MV_EXPAND`` command to expand multi-valued fields."""
+        self._commands.append(f"MV_EXPAND {field}")
+        return self
+
+    def pipe(self, raw_command: str) -> "ESQLQuery":
+        """Append a raw ES|QL command string.
+
+        Escape hatch for commands not yet covered by the fluent API.
+        """
+        self._commands.append(raw_command)
+        return self
+
+    # ------------------------------------------------------------------
+    # Build & render
+    # ------------------------------------------------------------------
+
+    def build(self) -> str:
+        """Render the query as an ES|QL string.
+
+        Returns:
+            The full ES|QL query string with pipe delimiters.
+
+        Raises:
+            ValueError: If no source command (FROM/ROW) was specified.
+        """
+        if not self._commands:
+            raise ValueError(
+                "Cannot build an empty ES|QL query. "
+                "Start with ESQLQuery('index') or ESQLQuery.row(...)."
+            )
+        first = self._commands[0].strip()
+        if not (first.startswith("FROM") or first.startswith("ROW")):
+            raise ValueError(
+                f"ES|QL query must start with FROM or ROW, got: {first[:30]!r}"
+            )
+        return "\n| ".join(self._commands)
+
+    def to_request_body(
+        self,
+        *,
+        params: Optional[List[Any]] = None,
+        filter: Optional[Dict[str, Any]] = None,
+        columnar: bool = False,
+    ) -> Dict[str, Any]:
+        """Render the query as a ``_query`` API request body.
+
+        Args:
+            params: Positional parameter values for ``?`` placeholders.
+            filter: Optional Query DSL pre-filter.
+            columnar: Return results in columnar format.
+        """
+        body: Dict[str, Any] = {"query": self.build()}
+        if params:
+            body["params"] = params
+        if filter:
+            body["filter"] = filter
+        if columnar:
+            body["columnar"] = True
+        return body
+
+    def __str__(self) -> str:
+        """Return the rendered ES|QL query string."""
+        return self.build()
+
+    def __repr__(self) -> str:
+        return f"ESQLQuery(commands={len(self._commands)})"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_value(v: Any) -> str:
+    """Format a Python value for ES|QL literal syntax."""
+    if isinstance(v, str):
+        # Escape internal double quotes
+        escaped = v.replace('"', '\\"')
+        return f'"{escaped}"'
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if v is None:
+        return "null"
+    return str(v)

--- a/tests/unit/core/test_esql_builder.py
+++ b/tests/unit/core/test_esql_builder.py
@@ -1,0 +1,268 @@
+"""
+Unit tests for the ES|QL fluent query builder.
+"""
+
+import pytest
+
+from elastro.core.esql.builder import ESQLQuery, _format_value
+
+# ---------------------------------------------------------------------------
+# Source command tests
+# ---------------------------------------------------------------------------
+
+
+class TestSourceCommands:
+    """Test FROM and ROW source commands."""
+
+    def test_from_simple(self):
+        q = ESQLQuery("logs-*").build()
+        assert q == "FROM logs-*"
+
+    def test_from_classmethod(self):
+        q = ESQLQuery.from_("logs-*").build()
+        assert q == "FROM logs-*"
+
+    def test_from_with_metadata(self):
+        q = ESQLQuery.from_("logs-*", metadata=["_index", "_id"]).build()
+        assert q == "FROM logs-* METADATA _index, _id"
+
+    def test_row_single_field(self):
+        q = ESQLQuery.row(name="Alice").build()
+        assert q == 'ROW name = "Alice"'
+
+    def test_row_multiple_fields(self):
+        q = ESQLQuery.row(x=1, y=2.5, active=True).build()
+        assert "x = 1" in q
+        assert "y = 2.5" in q
+        assert "active = true" in q
+
+    def test_row_null_value(self):
+        q = ESQLQuery.row(val=None).build()
+        assert "val = null" in q
+
+    def test_empty_query_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            ESQLQuery().build()
+
+
+# ---------------------------------------------------------------------------
+# Processing command tests
+# ---------------------------------------------------------------------------
+
+
+class TestProcessingCommands:
+    """Test all processing commands."""
+
+    def test_where(self):
+        q = ESQLQuery("logs-*").where("status >= 400").build()
+        assert "| WHERE status >= 400" in q
+
+    def test_where_chained(self):
+        q = (
+            ESQLQuery("logs-*")
+            .where("status >= 400")
+            .where("@timestamp > now() - 1h")
+            .build()
+        )
+        assert q.count("WHERE") == 2
+
+    def test_eval_single(self):
+        q = ESQLQuery("logs-*").eval("rate = bytes / duration").build()
+        assert "| EVAL rate = bytes / duration" in q
+
+    def test_eval_multiple(self):
+        q = ESQLQuery("logs-*").eval("a = 1", "b = 2").build()
+        assert "| EVAL a = 1, b = 2" in q
+
+    def test_stats_without_by(self):
+        q = ESQLQuery("logs-*").stats("total = COUNT(*)").build()
+        assert "| STATS total = COUNT(*)" in q
+        assert "BY" not in q
+
+    def test_stats_with_by_string(self):
+        q = ESQLQuery("logs-*").stats("avg_bytes = AVG(bytes)", by="host").build()
+        assert "| STATS avg_bytes = AVG(bytes) BY host" in q
+
+    def test_stats_with_by_list(self):
+        q = ESQLQuery("logs-*").stats("cnt = COUNT(*)", by=["host", "service"]).build()
+        assert "BY host, service" in q
+
+    def test_sort_asc(self):
+        q = ESQLQuery("logs-*").sort("name").build()
+        assert "| SORT name ASC" in q
+
+    def test_sort_desc(self):
+        q = ESQLQuery("logs-*").sort("timestamp", desc=True).build()
+        assert "| SORT timestamp DESC" in q
+
+    def test_sort_explicit_order(self):
+        q = ESQLQuery("logs-*").sort("age", order="DESC").build()
+        assert "| SORT age DESC" in q
+
+    def test_sort_multiple_fields(self):
+        q = ESQLQuery("logs-*").sort("host", "service", desc=True).build()
+        assert "host DESC" in q
+        assert "service DESC" in q
+
+    def test_limit(self):
+        q = ESQLQuery("logs-*").limit(25).build()
+        assert "| LIMIT 25" in q
+
+    def test_limit_invalid_raises(self):
+        with pytest.raises(ValueError, match="positive integer"):
+            ESQLQuery("logs-*").limit(-1).build()
+
+    def test_limit_zero_raises(self):
+        with pytest.raises(ValueError, match="positive integer"):
+            ESQLQuery("logs-*").limit(0)
+
+    def test_keep(self):
+        q = ESQLQuery("logs-*").keep("name", "age", "status").build()
+        assert "| KEEP name, age, status" in q
+
+    def test_drop(self):
+        q = ESQLQuery("logs-*").drop("_id", "_score").build()
+        assert "| DROP _id, _score" in q
+
+    def test_rename(self):
+        q = ESQLQuery("logs-*").rename(old_name="new_name").build()
+        assert "| RENAME old_name AS new_name" in q
+
+    def test_dissect(self):
+        q = ESQLQuery("logs-*").dissect("message", "%{ip} %{method}").build()
+        assert '| DISSECT message "%{ip} %{method}"' in q
+
+    def test_dissect_with_separator(self):
+        q = ESQLQuery("logs-*").dissect("tags", "%{tag}", append_separator=",").build()
+        assert 'APPEND_SEPARATOR=","' in q
+
+    def test_grok(self):
+        q = ESQLQuery("logs-*").grok("message", "%{IP:client} %{WORD:method}").build()
+        assert '| GROK message "%{IP:client} %{WORD:method}"' in q
+
+    def test_enrich_basic(self):
+        q = ESQLQuery("logs-*").enrich("geo-policy").build()
+        assert "| ENRICH geo-policy" in q
+
+    def test_enrich_full(self):
+        q = (
+            ESQLQuery("logs-*")
+            .enrich("geo-policy", on="client_ip", with_fields=["country", "city"])
+            .build()
+        )
+        assert "ON client_ip" in q
+        assert "WITH country, city" in q
+
+    def test_mv_expand(self):
+        q = ESQLQuery("logs-*").mv_expand("tags").build()
+        assert "| MV_EXPAND tags" in q
+
+    def test_pipe_raw(self):
+        q = ESQLQuery("logs-*").pipe("WHERE custom_condition = true").build()
+        assert "| WHERE custom_condition = true" in q
+
+
+# ---------------------------------------------------------------------------
+# Full pipeline tests
+# ---------------------------------------------------------------------------
+
+
+class TestFullPipeline:
+    """Test complex multi-command queries."""
+
+    def test_analytics_pipeline(self):
+        q = (
+            ESQLQuery("logs-*")
+            .where("status_code >= 400")
+            .where("@timestamp > now() - 1h")
+            .stats("avg_response = AVG(response_time)", by="service.name")
+            .sort("avg_response", desc=True)
+            .limit(25)
+            .build()
+        )
+        parts = q.split("\n| ")
+        assert len(parts) == 6
+        assert parts[0] == "FROM logs-*"
+        assert parts[1] == "WHERE status_code >= 400"
+        assert parts[5] == "LIMIT 25"
+
+    def test_transform_pipeline(self):
+        q = (
+            ESQLQuery.from_("metrics-*", metadata=["_index"])
+            .where("cpu > 90")
+            .eval("cpu_pct = cpu / 100")
+            .keep("host", "cpu_pct", "@timestamp")
+            .sort("cpu_pct", desc=True)
+            .limit(100)
+            .build()
+        )
+        assert "FROM metrics-* METADATA _index" in q
+        assert "EVAL cpu_pct = cpu / 100" in q
+        assert "KEEP host, cpu_pct, @timestamp" in q
+
+    def test_str_method(self):
+        q = ESQLQuery("test-index").limit(5)
+        assert str(q) == "FROM test-index\n| LIMIT 5"
+
+    def test_repr_method(self):
+        q = ESQLQuery("test-index").where("x > 1").limit(5)
+        assert repr(q) == "ESQLQuery(commands=3)"
+
+
+# ---------------------------------------------------------------------------
+# Request body tests
+# ---------------------------------------------------------------------------
+
+
+class TestRequestBody:
+    """Test to_request_body() serialization."""
+
+    def test_basic_body(self):
+        body = ESQLQuery("logs-*").limit(10).to_request_body()
+        assert body["query"] == "FROM logs-*\n| LIMIT 10"
+        assert "params" not in body
+        assert "filter" not in body
+        assert "columnar" not in body
+
+    def test_body_with_params(self):
+        body = ESQLQuery("logs-*").where("host = ?").to_request_body(params=["web-01"])
+        assert body["params"] == ["web-01"]
+
+    def test_body_with_filter(self):
+        dsl_filter = {"term": {"environment": "production"}}
+        body = ESQLQuery("logs-*").to_request_body(filter=dsl_filter)
+        assert body["filter"] == dsl_filter
+
+    def test_body_columnar(self):
+        body = ESQLQuery("logs-*").to_request_body(columnar=True)
+        assert body["columnar"] is True
+
+
+# ---------------------------------------------------------------------------
+# Value formatting tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatValue:
+    """Test _format_value helper."""
+
+    def test_string(self):
+        assert _format_value("hello") == '"hello"'
+
+    def test_string_with_quotes(self):
+        assert _format_value('say "hi"') == '"say \\"hi\\""'
+
+    def test_integer(self):
+        assert _format_value(42) == "42"
+
+    def test_float(self):
+        assert _format_value(3.14) == "3.14"
+
+    def test_bool_true(self):
+        assert _format_value(True) == "true"
+
+    def test_bool_false(self):
+        assert _format_value(False) == "false"
+
+    def test_none(self):
+        assert _format_value(None) == "null"


### PR DESCRIPTION
- Add elastro/core/esql/ package with fluent query builder:
  - FROM, ROW source commands with METADATA support
  - WHERE, EVAL, STATS (BY), SORT, LIMIT processing commands
  - KEEP, DROP, RENAME column projection
  - DISSECT, GROK, ENRICH, MV_EXPAND advanced commands
  - Raw pipe() escape hatch for unsupported commands
  - to_request_body() with params, filter, columnar support
- Add CLI commands:
  - 'elastro esql query' — execute from string, file, or stdin with table/json/csv/raw output and --save support
  - 'elastro esql build' — construct queries via CLI flags with optional --execute for immediate execution
- 46 unit tests covering all builder methods, full pipelines, request body serialization, and value formatting