### PR TITLE
fix(release): exclude empty scan placeholder from GitHub release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,8 +147,8 @@ jobs:
         name: Release v${{ env.VERSION }}
         body_path: release-notes.md
         files: |
-          security/sbom/*
-          security/scans/*
+          security/sbom/*.zst
+          security/scans/*.zst
           dist/*
 
     - name: Publish to PyPI

--- a/security/scans/README.md
+++ b/security/scans/README.md
@@ -1,0 +1,4 @@
+# ReleaseFlow scan artifacts
+
+Compressed Trivy reports are written here during release (`api-<version>.trivy.json.zst`).
+These files are attached to GitHub releases, not committed to the repo.


### PR DESCRIPTION
GitHub rejects release assets with size 0. The security/scans/.gitkeep placeholder matched security/scans/* and failed after wheel/sdist uploads. Restrict release attachments to compressed SBOM/scan artifacts (*.zst) and dist/*; document the scans directory with README instead of .gitkeep.